### PR TITLE
Add module inventory

### DIFF
--- a/PORTING_NOTES.md
+++ b/PORTING_NOTES.md
@@ -11,3 +11,13 @@ This document summarizes core functions, dependencies, and allocation models for
 | `ChirpGenerator.hpp` | `genChirp` | `<complex>`, `<cmath>` (includes `Pothos/Config.hpp` for macros) | Writes to caller-provided buffer; no dynamic allocation | Independent; remove Pothos include if unused |
 | `LoRaDetector.hpp` | `feed`, `detect` | `kissfft.hh`, `<vector>` | Internal `std::vector` buffers for FFT | Independent; no external framework |
 
+# Module Inventory
+
+| Module | Files |
+| --- | --- |
+| Encoder/Decoder | `LoRaEncoder.cpp`, `LoRaDecoder.cpp`, `LoRaCodes.hpp` |
+| Mod/Demod | `LoRaMod.cpp`, `LoRaDemod.cpp` |
+| Chirp/Detector | `ChirpGenerator.hpp`, `LoRaDetector.hpp` |
+| Utilities | `BlockGen.cpp`, `TestCodesSx.cpp`, `TestDetector.cpp`, `TestGen.cpp`, `TestHamming.cpp`, `TestLoopback.cpp` |
+| FFT | `kissfft.hh` |
+


### PR DESCRIPTION
## Summary
- List and categorize top-level source files into Encoder/Decoder, Mod/Demod, Chirp/Detector, Utilities, and FFT modules
- Document classification in a new "Module Inventory" section in `PORTING_NOTES.md`

## Testing
- `cmake -S . -B build` *(fails: Could not find Pothos package)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4a5a67ec832991e11880e566f67a