### PR TITLE
docs: highlight legacy pothos wrappers

### DIFF
--- a/PORTING_NOTES.md
+++ b/PORTING_NOTES.md
@@ -21,3 +21,13 @@ This document summarizes core functions, dependencies, and allocation models for
 | Utilities | `BlockGen.cpp`, `TestCodesSx.cpp`, `TestDetector.cpp`, `TestGen.cpp`, `TestHamming.cpp`, `TestLoopback.cpp` |
 | FFT | `kissfft.hh` |
 
+## Pothos-only wrappers
+
+These files remain in the legacy portion and will not be ported to the core library:
+
+- `BlockGen.cpp`
+- `TestGen.cpp`
+- `TestHamming.cpp`
+- `TestDetector.cpp`
+- `TestLoopback.cpp`
+


### PR DESCRIPTION
## Summary
- document Pothos-only wrapper files that will remain in legacy and not be ported

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Pothos")*

------
https://chatgpt.com/codex/tasks/task_e_68bc4b0e40b08329b8015e35496c906e