### PR TITLE
docs: enumerate algorithmic files for extraction

### DIFF
--- a/PORTING_NOTES.md
+++ b/PORTING_NOTES.md
@@ -33,3 +33,17 @@ These files remain in the legacy portion and will not be ported to the core libr
 - `TestDetector.cpp`
 - `TestLoopback.cpp`
 
+## Files to extract
+
+| Path | Allocation |
+| --- | --- |
+| `LoRaMod.cpp` | Runtime |
+| `LoRaDemod.cpp` | Init + runtime |
+| `LoRaEncoder.cpp` | Runtime |
+| `LoRaDecoder.cpp` | Runtime |
+| `ChirpGenerator.hpp` | None |
+| `LoRaDetector.hpp` | Initialization only |
+| `LoRaCodes.hpp` | None |
+| `kissfft.hh` | Initialization only |
+| `TestCodesSx.cpp` | Runtime |
+


### PR DESCRIPTION
## Summary
- list algorithmic modules and utilities to extract for porting
- note whether each file allocates memory at init or runtime

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Pothos")*

------
https://chatgpt.com/codex/tasks/task_e_68bc4c7cada08329a8bd8552942601da