### PR TITLE
Add baseline vector generation helper

### DIFF
--- a/scripts/generate_baseline_vectors.py
+++ b/scripts/generate_baseline_vectors.py
@@ -1,84 +1,40 @@
 #!/usr/bin/env python3
-"""Generate baseline vectors using the original LoRa-SDR implementation.
+"""Generate baseline vectors using the original LoRa-SDR binary.
 
-Prerequisites
--------------
-* A C++ compiler and CMake capable of building the original LoRa-SDR repository.  The build is expected to live in ``external/lorasdr_orig``.
-* Python 3.8+
-* Python packages: ``numpy``, ``pandas``
-* Optional package: ``pyyaml`` if YAML manifests are preferred, otherwise JSON is used.
-* Environment variables:
-    * ``LORASDR_ORIG`` – path to the original LoRa-SDR source tree (defaults to ``external/lorasdr_orig``).
-    * ``LORASDR_BUILD`` – path to the build directory (defaults to ``<LORASDR_ORIG>/build``).
-
-The script builds the original project if needed and runs an AWGN simulation for a matrix of spread-factors (SF7/SF9/SF12) and coding rates (CR 4/5–4/8) at a fixed SNR of 10 dB.  At each key boundary the intermediate data is written to ``.bin`` and ``.csv`` files under ``legacy_vectors/lorasdr_baseline/<sf>_<cr>_<snr>/``.  A manifest is emitted with metadata and checksums so downstream tests can verify integrity.
+The script runs the ``lora_awgn_sim`` example from the reference
+implementation for a single set of parameters and stores the resulting
+files under ``legacy_vectors/lorasdr_baseline``.  A ``manifest.json`` file
+with SHA256 checksums is written so downstream tests can verify the data.
 """
 
+from __future__ import annotations
+
+import argparse
 import hashlib
 import json
 import os
 import pathlib
 import subprocess
 import sys
-from dataclasses import dataclass, asdict
+from dataclasses import asdict, dataclass
 from typing import List
 
-import numpy as np
-import pandas as pd
 
+def run(cmd: List[str]) -> None:
+    """Run ``cmd`` and raise if it exits with a non-zero status."""
 
-def run(cmd: List[str], cwd: pathlib.Path | None = None) -> None:
-    """Run ``cmd`` and raise on failure."""
     print(f"[run] {' '.join(cmd)}", file=sys.stderr)
-    subprocess.run(cmd, check=True, cwd=cwd)
+    subprocess.run(cmd, check=True)
 
 
 def compute_checksum(path: pathlib.Path) -> str:
     """Return the SHA256 checksum for ``path``."""
-    h = hashlib.sha256()
-    with path.open('rb') as handle:
-        for chunk in iter(lambda: handle.read(65536), b''):
-            h.update(chunk)
-    return h.hexdigest()
 
-
-def ensure_build(src: pathlib.Path, build: pathlib.Path) -> None:
-    """Build the original LoRa-SDR project if no build artifacts exist."""
-    lib_candidate = build / 'liblora.a'
-    if lib_candidate.exists():
-        print(f"Found existing build at {lib_candidate}")
-        return
-
-    build.mkdir(exist_ok=True)
-    run(['cmake', str(src)], cwd=build)
-    run(['cmake', '--build', '.', '--', '-j4'], cwd=build)
-
-
-def run_awgn_simulation(src: pathlib.Path, sf: int, cr: str, snr: float, seed: int, out_dir: pathlib.Path) -> None:
-    """Invoke the original AWGN simulation.
-
-    This function assumes that the original repository provides a binary
-    called ``lora_awgn_sim`` that accepts parameters shown below and writes
-    intermediate results to the supplied output directory.  The binary is
-    part of LoRa-SDR's examples and is expected to be produced by the build
-    step above.  If the binary is not present the function raises a
-    ``RuntimeError`` with instructions for the user.
-    """
-    sim_bin = src / 'build' / 'lora_awgn_sim'
-    if not sim_bin.exists():
-        raise RuntimeError(
-            f"AWGN simulation binary '{sim_bin}' not found. Ensure the original project is built and provides this tool."
-        )
-
-    cmd = [
-        str(sim_bin),
-        f'--sf={sf}',
-        f'--cr={cr}',
-        f'--snr={snr}',
-        f'--seed={seed}',
-        f'--out={out_dir}'
-    ]
-    run(cmd, cwd=src)
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 @dataclass
@@ -88,7 +44,7 @@ class FileRecord:
 
 
 @dataclass
-class VectorRecord:
+class Manifest:
     sf: int
     cr: str
     snr: float
@@ -97,37 +53,52 @@ class VectorRecord:
 
 
 def main() -> None:
-    src = pathlib.Path(os.environ.get('LORASDR_ORIG', 'external/lorasdr_orig')).resolve()
-    build = pathlib.Path(os.environ.get('LORASDR_BUILD', src / 'build')).resolve()
+    parser = argparse.ArgumentParser(description="Generate baseline vectors via LoRa-SDR")
+    parser.add_argument("--sf", type=int, required=True, help="Spreading factor")
+    parser.add_argument("--cr", required=True, help="Coding rate, e.g. 4/5")
+    parser.add_argument("--snr", type=float, required=True, help="SNR in dB")
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="Output subdirectory name under legacy_vectors/lorasdr_baseline",
+    )
+    parser.add_argument("--seed", type=int, default=0, help="Random seed")
+    parser.add_argument(
+        "--binary",
+        default=os.environ.get("LORASDR_AWGN_BIN", "external/lorasdr_orig/build/lora_awgn_sim"),
+        help="Path to the lora_awgn_sim binary",
+    )
+    args = parser.parse_args()
 
-    ensure_build(src, build)
+    awgn_bin = pathlib.Path(args.binary).resolve()
+    if not awgn_bin.is_file():
+        parser.error(f"AWGN simulation binary not found: {awgn_bin}")
 
-    profiles = [(sf, cr, 10.0) for sf in (7, 9, 12) for cr in ('4/5', '4/6', '4/7', '4/8')]
-    seed = 0
-    manifest: List[VectorRecord] = []
+    base_dir = pathlib.Path("legacy_vectors/lorasdr_baseline")
+    out_dir = base_dir / args.out
+    out_dir.mkdir(parents=True, exist_ok=True)
 
-    base_out = pathlib.Path('legacy_vectors/lorasdr_baseline')
-    base_out.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        str(awgn_bin),
+        f"--sf={args.sf}",
+        f"--cr={args.cr}",
+        f"--snr={args.snr}",
+        f"--seed={args.seed}",
+        f"--out={out_dir}",
+    ]
+    run(cmd)
 
-    for sf, cr, snr in profiles:
-        subdir = base_out / f'sf{sf}_{cr.replace('/', '-')}_{int(snr)}'
-        subdir.mkdir(parents=True, exist_ok=True)
-        run_awgn_simulation(src, sf, cr, snr, seed, subdir)
+    files: List[FileRecord] = []
+    for path in sorted(out_dir.glob("*")):
+        if path.name == "manifest.json":
+            continue
+        files.append(FileRecord(path.name, compute_checksum(path)))
 
-        files = []
-        for path in sorted(subdir.glob('*')):
-            if path.name == 'manifest.json':
-                continue
-            checksum = compute_checksum(path)
-            files.append(FileRecord(path.name, checksum))
-
-        manifest.append(VectorRecord(sf, cr, snr, seed, files))
-
-    manifest_path = base_out / 'manifest.json'
-    with manifest_path.open('w') as handle:
-        json.dump([asdict(m) for m in manifest], handle, indent=2)
-    print(f"Wrote manifest to {manifest_path}")
+    manifest = Manifest(args.sf, args.cr, args.snr, args.seed, files)
+    with (out_dir / "manifest.json").open("w") as handle:
+        json.dump(asdict(manifest), handle, indent=2)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- add parameterised script for invoking LoRa-SDR AWGN simulation
- write per-run manifest with SHA256 checksums under `legacy_vectors/lorasdr_baseline`

## Testing
- `python -m py_compile scripts/generate_baseline_vectors.py`
- `python scripts/generate_baseline_vectors.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68bc537dd7f08329898b8cc1257b7983