### PR TITLE
Build lora_phy static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,15 @@
 cmake_minimum_required(VERSION 3.5)
-project(lora_phy CXX)
+project(lora_phy LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-add_library(lora_phy
-    src/phy/LoRaMod.cpp
-    src/phy/LoRaDemod.cpp
-    src/phy/LoRaEncoder.cpp
-    src/phy/LoRaDecoder.cpp
-)
+file(GLOB LORA_PHY_SOURCES CONFIGURE_DEPENDS src/phy/*.cpp)
+
+add_library(lora_phy STATIC ${LORA_PHY_SOURCES})
 
 target_include_directories(lora_phy PUBLIC include)
+
+# ensure headers like kissfft.hh are part of the target for IDEs
+target_sources(lora_phy PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include/lora_phy/kissfft.hh)
 


### PR DESCRIPTION
## Summary
- Build LoRa PHY sources into standalone `lora_phy` static library
- Include `kissfft.hh` and omit Pothos build hooks

## Testing
- `cmake ..`
- `cmake --build .`


------
https://chatgpt.com/codex/tasks/task_e_68bc59cad15c83299c20ce2b36866a41