### PR TITLE
Add lora_phy vector generation harness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,3 +13,6 @@ target_include_directories(lora_phy PUBLIC include)
 # ensure headers like kissfft.hh are part of the target for IDEs
 target_sources(lora_phy PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include/lora_phy/kissfft.hh)
 
+
+add_executable(lora_phy_vector_dump runners/lora_phy_vector_dump.cpp)
+target_link_libraries(lora_phy_vector_dump PRIVATE lora_phy)

--- a/README.md
+++ b/README.md
@@ -57,3 +57,20 @@ cmake ../
 make -j4
 sudo make install
 ```
+
+## Generating reference vectors
+
+A small utility built from the `lora_phy` library can dump deterministic
+vectors for testing.  After building the project with CMake, run:
+
+```bash
+cmake -B build -S .
+cmake --build build
+python3 scripts/generate_lora_phy_vectors.py --sf 7 --seed 1 --out example
+```
+
+The script invokes `build/lora_phy_vector_dump` and stores outputs under
+`vectors/lora_phy_baseline/example`.  A `manifest.json` containing
+SHA256 checksums is written so the vectors can be recreated locally.
+Generated `.bin` and `.csv` files are ignored by Git.
+

--- a/runners/lora_phy_vector_dump.cpp
+++ b/runners/lora_phy_vector_dump.cpp
@@ -1,0 +1,77 @@
+#include <lora_phy/phy.hpp>
+#include <vector>
+#include <complex>
+#include <fstream>
+#include <random>
+#include <iostream>
+#include <cstdint>
+#include <cstring>
+
+int main(int argc, char** argv) {
+    unsigned sf = 7;
+    unsigned seed = 0;
+    size_t byte_count = 16;
+    const char* out_dir = nullptr;
+
+    for (int i = 1; i < argc; ++i) {
+        const char* arg = argv[i];
+        if (std::strncmp(arg, "--sf=", 5) == 0) sf = std::stoul(arg + 5);
+        else if (std::strncmp(arg, "--seed=", 7) == 0) seed = std::stoul(arg + 7);
+        else if (std::strncmp(arg, "--bytes=", 8) == 0) byte_count = std::stoul(arg + 8);
+        else if (std::strncmp(arg, "--out=", 6) == 0) out_dir = arg + 6;
+        else {
+            std::cerr << "Unknown argument: " << arg << std::endl;
+            return 1;
+        }
+    }
+
+    if (!out_dir) {
+        std::cerr << "--out argument is required" << std::endl;
+        return 1;
+    }
+
+    std::mt19937 rng(seed);
+    std::uniform_int_distribution<int> dist(0, 255);
+    std::vector<uint8_t> payload(byte_count);
+    for (size_t i = 0; i < byte_count; i++) payload[i] = static_cast<uint8_t>(dist(rng));
+
+    std::vector<uint16_t> symbols(byte_count * 2);
+    size_t symbol_count = lora_phy::lora_encode(payload.data(), byte_count, symbols.data(), sf);
+
+    const size_t samples_per_symbol = 1u << sf;
+    std::vector<std::complex<float>> samples(symbol_count * samples_per_symbol);
+    size_t sample_count = lora_phy::lora_modulate(symbols.data(), symbol_count, samples.data(), sf);
+
+    std::vector<uint16_t> demod(symbol_count);
+    lora_phy::lora_demodulate(samples.data(), sample_count, demod.data(), sf);
+
+    std::vector<uint8_t> decoded(byte_count);
+    lora_phy::lora_decode(demod.data(), symbol_count, decoded.data());
+
+    std::string base(out_dir);
+
+    std::ofstream f;
+    f.open(base + "/payload.bin", std::ios::binary);
+    f.write(reinterpret_cast<const char*>(payload.data()), payload.size());
+    f.close();
+
+    f.open(base + "/symbols.csv");
+    for (size_t i = 0; i < symbol_count; i++) f << symbols[i] << "\n";
+    f.close();
+
+    f.open(base + "/iq_samples.csv");
+    for (size_t i = 0; i < sample_count; i++)
+        f << samples[i].real() << "," << samples[i].imag() << "\n";
+    f.close();
+
+    f.open(base + "/demod_symbols.csv");
+    for (size_t i = 0; i < symbol_count; i++) f << demod[i] << "\n";
+    f.close();
+
+    f.open(base + "/decoded.bin", std::ios::binary);
+    f.write(reinterpret_cast<const char*>(decoded.data()), decoded.size());
+    f.close();
+
+    return 0;
+}
+

--- a/scripts/generate_lora_phy_vectors.py
+++ b/scripts/generate_lora_phy_vectors.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Generate reference vectors using the new lora_phy library.
+
+The script runs a small CLI that exercises the lora_phy library and
+writes deterministic payloads, symbols and IQ samples.  A manifest file
+with SHA256 checksums is written so downstream tests can verify the data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from typing import List
+
+
+def run(cmd: List[str]) -> None:
+    """Run ``cmd`` and raise if it exits with a non-zero status."""
+
+    print(f"[run] {' '.join(cmd)}", file=sys.stderr)
+    subprocess.run(cmd, check=True)
+
+
+def compute_checksum(path: pathlib.Path) -> str:
+    """Return the SHA256 checksum for ``path``."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass
+class FileRecord:
+    name: str
+    sha256: str
+
+
+@dataclass
+class Manifest:
+    sf: int
+    seed: int
+    bytes: int
+    files: List[FileRecord]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate vectors via lora_phy")
+    parser.add_argument("--sf", type=int, required=True, help="Spreading factor")
+    parser.add_argument("--seed", type=int, default=0, help="Random seed")
+    parser.add_argument("--bytes", type=int, default=16, help="Number of payload bytes")
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="Output subdirectory name under vectors/lora_phy_baseline",
+    )
+    parser.add_argument(
+        "--binary",
+        default=os.environ.get("LORAPHY_VECTOR_BIN", "build/lora_phy_vector_dump"),
+        help="Path to the lora_phy_vector_dump binary",
+    )
+    args = parser.parse_args()
+
+    vector_bin = pathlib.Path(args.binary).resolve()
+    if not vector_bin.is_file():
+        parser.error(f"Vector dump binary not found: {vector_bin}")
+
+    base_dir = pathlib.Path("vectors/lora_phy_baseline")
+    out_dir = base_dir / args.out
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        str(vector_bin),
+        f"--sf={args.sf}",
+        f"--seed={args.seed}",
+        f"--bytes={args.bytes}",
+        f"--out={out_dir}",
+    ]
+    run(cmd)
+
+    files: List[FileRecord] = []
+    for path in sorted(out_dir.glob("*")):
+        if path.name == "manifest.json":
+            continue
+        files.append(FileRecord(path.name, compute_checksum(path)))
+
+    manifest = Manifest(args.sf, args.seed, args.bytes, files)
+    with (out_dir / "manifest.json").open("w") as handle:
+        json.dump(asdict(manifest), handle, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/vectors/lora_phy_baseline/.gitignore
+++ b/vectors/lora_phy_baseline/.gitignore
@@ -1,0 +1,3 @@
+# Ignore generated lora_phy baseline vectors and manifests
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- add C++ `lora_phy_vector_dump` utility and expose it via CMake
- provide `generate_lora_phy_vectors.py` script to create vectors and manifests
- document vector generation in README and ignore produced data

## Testing
- `python3 -m py_compile scripts/generate_lora_phy_vectors.py`
- `cmake -B build -S .`
- `cmake --build build`
- `python3 scripts/generate_lora_phy_vectors.py --sf 7 --seed 1 --out test`


------
https://chatgpt.com/codex/tasks/task_e_68bc5a8fbb708329ae06aeedcb4419ec