### PR TITLE
Use external FFT buffers in LoRaDetector

### DIFF
--- a/PORTING_NOTES.md
+++ b/PORTING_NOTES.md
@@ -9,7 +9,7 @@ This document summarizes core functions, dependencies, and allocation models for
 | `LoRaEncoder.cpp` | `LoRaEncoder::work`, `encodeFec` | Pothos framework, `LoRaCodes.hpp` utilities | `std::vector` for data and symbols; output `Pothos::BufferChunk` | Pothos block wrapper; no Poco/JSON |
 | `LoRaDecoder.cpp` | `LoRaDecoder::work`, `drop` | Pothos framework, `LoRaCodes.hpp` | `std::vector` for buffers; output `Pothos::BufferChunk` | Pothos block wrapper; no Poco/JSON |
 | `ChirpGenerator.hpp` | `genChirp` | `<complex>`, `<cmath>` (includes `Pothos/Config.hpp` for macros) | Writes to caller-provided buffer; no dynamic allocation | Independent; remove Pothos include if unused |
-| `LoRaDetector.hpp` | `feed`, `detect` | `kissfft.hh`, `<vector>` | Internal `std::vector` buffers for FFT | Independent; no external framework |
+| `LoRaDetector.hpp` | `feed`, `detect` | `kissfft.hh`, `<complex>` | Uses caller-provided FFT work buffers and plan | Independent; no external framework |
 | `LoRaCodes.hpp` | `sx1272DataChecksum`, `diagonalInterleaveSx`, `grayToBinary16`, `SX1232RadioComputeWhitening` | Standard library (`<cstdint>`) only | Operates on caller buffers; no dynamic allocation | Contains CRC, interleaving, Gray mapping, whitening |
 | `kissfft.hh` | `kissfft::transform` | `<complex>`, `<vector>` (optional `<alloca.h>`) | Twiddles and stage data allocated in constructor (init-only) | Standalone FFT backend |
 

--- a/TestDetector.cpp
+++ b/TestDetector.cpp
@@ -5,6 +5,7 @@
 #include "LoRaDetector.hpp"
 #include "ChirpGenerator.hpp"
 #include <iostream>
+#include <vector>
 
 POTHOS_TEST_BLOCK("/lora/tests", test_detector)
 {
@@ -13,6 +14,11 @@ POTHOS_TEST_BLOCK("/lora/tests", test_detector)
     std::vector<std::complex<float>> downChirp(N);
     genChirp(downChirp.data(), N, 1, N, 0.0f, true, 1.0f, phaseAccum);
 
+    std::vector<std::complex<float>> fft_in(N);
+    std::vector<std::complex<float>> fft_out(N);
+    kissfft<float> fft(N, false);
+    LoRaDetector<float> detector(N, fft_in.data(), fft_out.data(), fft);
+
     for (size_t sym = 0; sym < N; sym++)
     {
         std::cout << "testing detector on symbol = " << sym << std::endl;
@@ -20,7 +26,6 @@ POTHOS_TEST_BLOCK("/lora/tests", test_detector)
         phaseAccum = M_PI/4; //some phase offset
         genChirp(chirp.data(), N, 1, N, float(2*M_PI*sym)/N, false, 1.0f, phaseAccum);
 
-        LoRaDetector<float> detector(N);
         for (size_t i = 0; i < N; i++) detector.feed(i, downChirp[i]*chirp[i]);
         float power, powerAvg, fIndex;
         const size_t index = detector.detect(power, powerAvg, fIndex);

--- a/include/lora_phy/LoRaDetector.hpp
+++ b/include/lora_phy/LoRaDetector.hpp
@@ -3,33 +3,34 @@
 
 #include "kissfft.hh"
 #include <complex>
-#include <vector>
 
 template <typename Type>
 class LoRaDetector
 {
 public:
-    LoRaDetector(const size_t N):
+    LoRaDetector(const size_t N,
+        std::complex<Type>* fft_in,
+        std::complex<Type>* fft_out,
+        kissfft<Type>& fft):
         N(N),
-        _fftInput(N),
-        _fftOutput(N),
-        _fft(N, false)
+        fft_in(fft_in),
+        fft_out(fft_out),
+        _fft(fft)
     {
         _powerScale = 20*std::log10(N);
-        return;
     }
 
     //! feed simply sets an input sample
     void feed(const size_t i, const std::complex<Type> &samp)
     {
-        _fftInput[i] = samp;
+        fft_in[i] = samp;
     }
 
     //! calculates argmax(abs(fft(input)))
     size_t detect(Type &power, Type &powerAvg, Type &fIndex, std::complex<Type> *fftOutput = nullptr)
     {
-        if (fftOutput == nullptr) fftOutput = _fftOutput.data();
-        _fft.transform(_fftInput.data(), fftOutput);
+        if (fftOutput == nullptr) fftOutput = fft_out;
+        _fft.transform(fft_in, fftOutput);
         size_t maxIndex = 0;
         Type maxValue = 0;
         double total = 0;
@@ -66,7 +67,7 @@ public:
 private:
     const size_t N;
     Type _powerScale;
-    std::vector<std::complex<Type>> _fftInput;
-    std::vector<std::complex<Type>> _fftOutput;
-    kissfft<Type> _fft;
+    std::complex<Type>* fft_in;
+    std::complex<Type>* fft_out;
+    kissfft<Type>& _fft;
 };

--- a/src/phy/LoRaDemod.cpp
+++ b/src/phy/LoRaDemod.cpp
@@ -8,16 +8,25 @@ size_t lora_demodulate(const std::complex<float>* samples, size_t sample_count,
 {
     const size_t N = size_t(1) << sf; // samples per symbol
     const size_t num_symbols = sample_count / N;
-    LoRaDetector<float> detector(N);
+    auto fft_in = new std::complex<float>[N];
+    auto fft_out = new std::complex<float>[N];
+    kissfft<float> fft(N, false);
 
-    for (size_t s = 0; s < num_symbols; ++s)
     {
-        const std::complex<float>* sym_samps = samples + s * N;
-        for (size_t i = 0; i < N; ++i) detector.feed(i, sym_samps[i]);
-        float p, pav, findex;
-        size_t idx = detector.detect(p, pav, findex);
-        out_symbols[s] = static_cast<uint16_t>(idx);
+        LoRaDetector<float> detector(N, fft_in, fft_out, fft);
+
+        for (size_t s = 0; s < num_symbols; ++s)
+        {
+            const std::complex<float>* sym_samps = samples + s * N;
+            for (size_t i = 0; i < N; ++i) detector.feed(i, sym_samps[i]);
+            float p, pav, findex;
+            size_t idx = detector.detect(p, pav, findex);
+            out_symbols[s] = static_cast<uint16_t>(idx);
+        }
     }
+
+    delete[] fft_in;
+    delete[] fft_out;
     return num_symbols;
 }
 


### PR DESCRIPTION
## Summary
- Make `LoRaDetector` use caller-provided FFT buffers and plan, removing internal `std::vector`
- Adapt `lora_demodulate` and test harness to supply workspace arrays and FFT plan
- Update porting notes for new allocation model

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5d6403b48329a27bed23879e0383