### PR TITLE
Refactor demodulator to use workspace

### DIFF
--- a/include/lora_phy/phy.hpp
+++ b/include/lora_phy/phy.hpp
@@ -2,8 +2,24 @@
 #include <cstddef>
 #include <cstdint>
 #include <complex>
+#include <lora_phy/kissfft.hh>
+
+template <typename T> class LoRaDetector;
 
 namespace lora_phy {
+
+// Workspace used by the demodulator to hold FFT buffers and detector instance.
+struct lora_demod_workspace {
+    size_t N{};
+    std::complex<float>* fft_in{};
+    std::complex<float>* fft_out{};
+    kissfft<float>* fft{};
+    LoRaDetector<float>* detector{};
+};
+
+// Initialize and clean up the demodulator workspace.
+void lora_demod_init(lora_demod_workspace* ws, unsigned sf);
+void lora_demod_free(lora_demod_workspace* ws);
 
 // Modulate an array of symbols into complex baseband samples.
 // samples_per_symbol = 1 << sf
@@ -11,9 +27,10 @@ size_t lora_modulate(const uint16_t* symbols, size_t symbol_count,
                      std::complex<float>* out_samples, unsigned sf,
                      float amplitude = 1.0f);
 
-// Demodulate complex samples into symbol indices.
-size_t lora_demodulate(const std::complex<float>* samples, size_t sample_count,
-                       uint16_t* out_symbols, unsigned sf);
+// Demodulate complex samples into symbol indices using a prepared workspace.
+size_t lora_demodulate(lora_demod_workspace* ws,
+                       const std::complex<float>* samples, size_t sample_count,
+                       uint16_t* out_symbols);
 
 // Simple Hamming(8,4) based encoder. Each input byte becomes two symbols.
 size_t lora_encode(const uint8_t* bytes, size_t byte_count,

--- a/runners/lora_phy_vector_dump.cpp
+++ b/runners/lora_phy_vector_dump.cpp
@@ -43,7 +43,10 @@ int main(int argc, char** argv) {
     size_t sample_count = lora_phy::lora_modulate(symbols.data(), symbol_count, samples.data(), sf);
 
     std::vector<uint16_t> demod(symbol_count);
-    lora_phy::lora_demodulate(samples.data(), sample_count, demod.data(), sf);
+    lora_phy::lora_demod_workspace demod_ws{};
+    lora_phy::lora_demod_init(&demod_ws, sf);
+    lora_phy::lora_demodulate(&demod_ws, samples.data(), sample_count, demod.data());
+    lora_phy::lora_demod_free(&demod_ws);
 
     std::vector<uint8_t> decoded(byte_count);
     lora_phy::lora_decode(demod.data(), symbol_count, decoded.data());

--- a/src/phy/LoRaDemod.cpp
+++ b/src/phy/LoRaDemod.cpp
@@ -3,30 +3,44 @@
 
 namespace lora_phy {
 
-size_t lora_demodulate(const std::complex<float>* samples, size_t sample_count,
-                       uint16_t* out_symbols, unsigned sf)
+void lora_demod_init(lora_demod_workspace* ws, unsigned sf)
 {
-    const size_t N = size_t(1) << sf; // samples per symbol
+    ws->N = size_t(1) << sf;
+    ws->fft_in = new std::complex<float>[ws->N];
+    ws->fft_out = new std::complex<float>[ws->N];
+    ws->fft = new kissfft<float>(ws->N, false);
+    ws->detector = new LoRaDetector<float>(ws->N, ws->fft_in, ws->fft_out, *ws->fft);
+}
+
+void lora_demod_free(lora_demod_workspace* ws)
+{
+    delete ws->detector;
+    delete ws->fft;
+    delete[] ws->fft_in;
+    delete[] ws->fft_out;
+    ws->detector = nullptr;
+    ws->fft = nullptr;
+    ws->fft_in = nullptr;
+    ws->fft_out = nullptr;
+    ws->N = 0;
+}
+
+size_t lora_demodulate(lora_demod_workspace* ws,
+                       const std::complex<float>* samples, size_t sample_count,
+                       uint16_t* out_symbols)
+{
+    const size_t N = ws->N; // samples per symbol
     const size_t num_symbols = sample_count / N;
-    auto fft_in = new std::complex<float>[N];
-    auto fft_out = new std::complex<float>[N];
-    kissfft<float> fft(N, false);
 
+    for (size_t s = 0; s < num_symbols; ++s)
     {
-        LoRaDetector<float> detector(N, fft_in, fft_out, fft);
-
-        for (size_t s = 0; s < num_symbols; ++s)
-        {
-            const std::complex<float>* sym_samps = samples + s * N;
-            for (size_t i = 0; i < N; ++i) detector.feed(i, sym_samps[i]);
-            float p, pav, findex;
-            size_t idx = detector.detect(p, pav, findex);
-            out_symbols[s] = static_cast<uint16_t>(idx);
-        }
+        const std::complex<float>* sym_samps = samples + s * N;
+        for (size_t i = 0; i < N; ++i) ws->detector->feed(i, sym_samps[i]);
+        float p, pav, findex;
+        size_t idx = ws->detector->detect(p, pav, findex);
+        out_symbols[s] = static_cast<uint16_t>(idx);
     }
 
-    delete[] fft_in;
-    delete[] fft_out;
     return num_symbols;
 }
 


### PR DESCRIPTION
## Summary
- Add dedicated workspace structure and init/free helpers for demodulation
- Rework LoRa demodulator to use pre-allocated workspace buffers and detector
- Update vector dump runner to allocate and pass workspace

## Testing
- `cmake --build .`


------
https://chatgpt.com/codex/tasks/task_e_68bc6a632ba0832997dc34ed6fce3a2a