### PR TITLE
Add allocation scan script and documentation

### DIFF
--- a/PORTING_NOTES.md
+++ b/PORTING_NOTES.md
@@ -47,3 +47,12 @@ These files remain in the legacy portion and will not be ported to the core libr
 | `kissfft.hh` | Initialization only |
 | `TestCodesSx.cpp` | Runtime |
 
+
+## Zero-allocation scan
+
+Run `scripts/scan_allocs.sh` to search `src` and `include` for dynamic allocation patterns such as `new`, `malloc`, `resize`, or `push_back`. The script writes matches to `alloc_report.txt`. The file is empty when the code base is "zero-alloc".
+
+```bash
+bash scripts/scan_allocs.sh
+cat alloc_report.txt
+```

--- a/alloc_report.txt
+++ b/alloc_report.txt
@@ -1,0 +1,4 @@
+src/phy/LoRaDemod.cpp:9:    ws->fft_in = new std::complex<float>[ws->N];
+src/phy/LoRaDemod.cpp:10:    ws->fft_out = new std::complex<float>[ws->N];
+src/phy/LoRaDemod.cpp:12:    ws->fft = new kissfft<float>(ws->fft_plan);
+src/phy/LoRaDemod.cpp:13:    ws->detector = new LoRaDetector<float>(ws->N, ws->fft_in, ws->fft_out, *ws->fft);

--- a/scripts/scan_allocs.sh
+++ b/scripts/scan_allocs.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# scan for dynamic allocation patterns in src and include
+OUT_FILE="${1:-alloc_report.txt}"
+
+PATTERN='\b(new|malloc|calloc|realloc|resize|push_back|emplace_back)\b'
+
+# Use ripgrep to search the source tree
+rg -n "$PATTERN" src include > "$OUT_FILE" || true
+
+echo "Allocation report saved to $OUT_FILE"


### PR DESCRIPTION
## Summary
- add `scan_allocs.sh` to search `src` and `include` for allocations
- check in `alloc_report.txt` listing current allocation sites
- document generating a zero-allocation report in `PORTING_NOTES.md`

## Testing
- `scripts/scan_allocs.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bc6da7defc8329a0b21bb22c298b31