### PR TITLE
Add semantic compatibility table and vector comparison tool

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -91,3 +91,9 @@ All input and output buffers are owned by the caller.  The library reads from or
 writes to them only for the duration of the call.  No asynchronous callbacks are
 involved; errors are reported solely through return codes.
 
+## Numeric conventions
+
+See `SEMANTIC_COMPATIBILITY.md` for sample scaling, bit ordering and other
+semantic requirements needed for vector compatibility with the reference
+implementation.
+

--- a/PORTING_NOTES.md
+++ b/PORTING_NOTES.md
@@ -56,3 +56,9 @@ Run `scripts/scan_allocs.sh` to search `src` and `include` for dynamic allocatio
 bash scripts/scan_allocs.sh
 cat alloc_report.txt
 ```
+
+## Numeric & semantic compatibility
+
+Compare vectors produced by the original LoRa-SDR code and the new library with
+`scripts/compare_vectors.py`. The script hashes all files in two directories and
+reports any mismatch, highlighting deviations in numeric conventions.

--- a/README_LoRaSDR_porting.md
+++ b/README_LoRaSDR_porting.md
@@ -112,7 +112,9 @@
 - **CRC**: polynomial, endian, initialization.
 - **Sync-word**: masking and header mapping exactly as required.
 
-**Deliverable**: “semantic decisions” table + vector updates if any convention is adjusted.
+**Deliverable**: “semantic decisions” table (`SEMANTIC_COMPATIBILITY.md`) and a
+vector comparison script (`scripts/compare_vectors.py`) to flag mismatches;
+regenerate vectors if any convention is adjusted.
 
 ---
 

--- a/SEMANTIC_COMPATIBILITY.md
+++ b/SEMANTIC_COMPATIBILITY.md
@@ -1,0 +1,19 @@
+# Numeric and Semantic Compatibility Decisions
+
+This document captures conventions that the lightweight LoRa PHY library
+must follow to remain bit‑exact with the original LoRa‑SDR implementation.
+
+| Aspect | Decision |
+| --- | --- |
+| IQ samples | Complex `float32` values with I in the real part and Q in the imaginary part. Samples are normalized to the range \[-1.0, 1.0). |
+| Symbol length | Each LoRa symbol contains exactly `N = 2^SF` samples. Demodulation assumes `sample_count` is an integer multiple of `N`. |
+| Dechirp | Base chirps start at phase 0.0. Modulation uses up‑chirps; demodulation multiplies by a down‑chirp generated with the same `genChirp` routine. |
+| Argmax policy | Symbol decision selects the first FFT bin with the highest magnitude‑squared. Ties resolve to the lowest index. |
+| Bit ordering | Gray mapping, diagonal interleaving and whitening operate on least‑significant bit first. Whitening uses the polynomial $x^7 + x^5 + 1$ with an initial LFSR value of `0xFF`. |
+| CRC | Modified CCITT‑16 with polynomial `0x1021` and SX1272 stream masking. |
+| Sync word | Two‑byte sync word applied via XOR against the header. Default private‑network value is `0x34`. |
+
+To verify compatibility between the new library and the reference
+implementation, generate vectors for both and compare them with
+`scripts/compare_vectors.py`. The tool performs a SHA256 check on every file
+and reports mismatches.

--- a/scripts/compare_vectors.py
+++ b/scripts/compare_vectors.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Compare two vector directories for bit-for-bit compatibility.
+
+Both directories must contain the files to compare.  If a ``manifest.json``
+file is present it will be ignored; actual file contents are hashed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import pathlib
+import sys
+from typing import Dict
+
+
+def compute_checksum(path: pathlib.Path) -> str:
+    """Return the SHA256 checksum for ``path``."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_checksums(directory: pathlib.Path) -> Dict[str, str]:
+    """Return a mapping of file name to SHA256 checksum for ``directory``."""
+
+    checksums: Dict[str, str] = {}
+    for path in sorted(directory.glob("*")):
+        if path.name == "manifest.json" or not path.is_file():
+            continue
+        checksums[path.name] = compute_checksum(path)
+    return checksums
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare vector directories")
+    parser.add_argument("ref", help="Reference vector directory")
+    parser.add_argument("test", help="Test vector directory")
+    args = parser.parse_args()
+
+    ref_dir = pathlib.Path(args.ref)
+    test_dir = pathlib.Path(args.test)
+    ref = load_checksums(ref_dir)
+    test = load_checksums(test_dir)
+
+    ok = True
+    for name, sha in ref.items():
+        other = test.get(name)
+        if other is None:
+            print(f"missing: {name}", file=sys.stderr)
+            ok = False
+        elif other != sha:
+            print(f"mismatch: {name}", file=sys.stderr)
+            ok = False
+    for name in set(test) - set(ref):
+        print(f"extra file: {name}", file=sys.stderr)
+        ok = False
+
+    if ok:
+        print("vectors match")
+        sys.exit(0)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- capture numeric and bit-level conventions in `SEMANTIC_COMPATIBILITY.md`
- add `scripts/compare_vectors.py` for SHA256-based vector comparisons
- update porting docs to reference the semantic table and comparison script

## Testing
- `scripts/compare_vectors.py --help`
- `bash scripts/scan_allocs.sh >/tmp/scan.log && cat alloc_report.txt`


------
https://chatgpt.com/codex/tasks/task_e_68bc6e77144c8329be5579519885b6a2