### PR TITLE
Use shared profile config for tests

### DIFF
--- a/tests/bit_exact_test.cpp
+++ b/tests/bit_exact_test.cpp
@@ -10,6 +10,8 @@
 struct Profile {
     std::string name;
     unsigned sf{};
+    unsigned bw{};
+    std::string cr;
     std::string dir;
 };
 
@@ -41,6 +43,8 @@ static bool load_profiles(const std::string& path, std::vector<Profile>& out) {
         std::string val = trim(line.substr(colon + 1));
         if (key == "name") current.name = val;
         else if (key == "sf") current.sf = static_cast<unsigned>(std::stoul(val));
+        else if (key == "bw") current.bw = static_cast<unsigned>(std::stoul(val));
+        else if (key == "cr") current.cr = val;
         else if (key == "dir") current.dir = val;
     }
     if (in_profile) out.push_back(current);
@@ -80,6 +84,11 @@ int main() {
     }
     bool ok = true;
     for (const auto& p : profiles) {
+        if (p.dir.empty()) {
+            std::cout << "Skipping profile " << p.name
+                      << " (no vector directory)" << std::endl;
+            continue;
+        }
         std::vector<std::complex<float>> samples;
         if (!load_iq_samples(p.dir + "/iq_samples.csv", samples)) {
             std::cerr << "Failed to load IQ samples for profile " << p.name << "\n";

--- a/tests/e2e_chain_test.cpp
+++ b/tests/e2e_chain_test.cpp
@@ -10,7 +10,9 @@
 struct Profile {
     std::string name;
     unsigned sf{};
-    std::string dir; // unused but parsed for compatibility
+    unsigned bw{};
+    std::string cr;
+    std::string dir; // optional
 };
 
 static std::string trim(const std::string& s) {
@@ -41,6 +43,8 @@ static bool load_profiles(const std::string& path, std::vector<Profile>& out) {
         std::string val = trim(line.substr(colon + 1));
         if (key == "name") current.name = val;
         else if (key == "sf") current.sf = static_cast<unsigned>(std::stoul(val));
+        else if (key == "bw") current.bw = static_cast<unsigned>(std::stoul(val));
+        else if (key == "cr") current.cr = val;
         else if (key == "dir") current.dir = val;
     }
     if (in_profile) out.push_back(current);

--- a/tests/profiles.yaml
+++ b/tests/profiles.yaml
@@ -1,4 +1,19 @@
-- 
-  name: sf7
+# Representative LoRa profiles used by tests
+# Fields: name, sf (spreading factor), bw (Hz), cr (coding rate),
+# and optional dir for vector data.
+-
+  name: sf7_bw125_cr45
   sf: 7
+  bw: 125000
+  cr: 4/5
   dir: vectors/lora_phy_baseline/sf7
+-
+  name: sf9_bw250_cr48
+  sf: 9
+  bw: 250000
+  cr: 4/8
+-
+  name: sf12_bw500_cr45
+  sf: 12
+  bw: 500000
+  cr: 4/5


### PR DESCRIPTION
## Summary
- Define representative LoRa profiles in tests/profiles.yaml
- Load profile SF/BW/CR in C++ test harnesses
- Iterate AWGN sweep over profiles from config

## Testing
- `g++ -std=c++17 tests/bit_exact_test.cpp src/phy/LoRaDecoder.cpp src/phy/LoRaDemod.cpp src/phy/LoRaEncoder.cpp src/phy/LoRaMod.cpp -Iinclude -o bit_exact_test`
- `./bit_exact_test` *(fails: Mismatch in profile sf7_bw125_cr45)*
- `g++ -std=c++17 tests/e2e_chain_test.cpp src/phy/LoRaDecoder.cpp src/phy/LoRaDemod.cpp src/phy/LoRaEncoder.cpp src/phy/LoRaMod.cpp -Iinclude -o e2e_chain_test`
- `./e2e_chain_test`
- `python3 tests/awgn_sweep.py --out tests/awgn_out --packets 1 --payload-bytes 2 --snr-start 0 --snr-stop 0 --snr-step 1`

------
https://chatgpt.com/codex/tasks/task_e_68bc75317800832983f672240084d451