### PR TITLE
Add allocation tracking test for modulate and demodulate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,3 +24,7 @@ target_link_libraries(bit_exact_test PRIVATE lora_phy)
 # End-to-end encode/modulate/demodulate test
 add_executable(e2e_chain_test tests/e2e_chain_test.cpp)
 target_link_libraries(e2e_chain_test PRIVATE lora_phy)
+
+# Allocation tracking test for modulate/demodulate
+add_executable(no_alloc_test tests/no_alloc_test.cpp)
+target_link_libraries(no_alloc_test PRIVATE lora_phy)

--- a/tests/alloc_tracker.h
+++ b/tests/alloc_tracker.h
@@ -1,0 +1,48 @@
+#pragma once
+#include <atomic>
+#include <cstddef>
+#include <cstdlib>
+#include <new>
+
+namespace alloc_tracker {
+
+inline std::atomic<std::size_t>& counter() {
+    static std::atomic<std::size_t> c{0};
+    return c;
+}
+
+inline void reset() {
+    counter().store(0, std::memory_order_relaxed);
+}
+
+inline std::size_t get() {
+    return counter().load(std::memory_order_relaxed);
+}
+
+struct Guard {
+    Guard() { reset(); }
+    ~Guard() = default;
+    std::size_t count() const { return get(); }
+};
+
+} // namespace alloc_tracker
+
+inline void* operator new(std::size_t size) {
+    alloc_tracker::counter().fetch_add(1, std::memory_order_relaxed);
+    if (void* p = std::malloc(size)) return p;
+    throw std::bad_alloc();
+}
+
+inline void operator delete(void* ptr) noexcept {
+    std::free(ptr);
+}
+
+inline void* operator new[](std::size_t size) {
+    alloc_tracker::counter().fetch_add(1, std::memory_order_relaxed);
+    if (void* p = std::malloc(size)) return p;
+    throw std::bad_alloc();
+}
+
+inline void operator delete[](void* ptr) noexcept {
+    std::free(ptr);
+}

--- a/tests/no_alloc_test.cpp
+++ b/tests/no_alloc_test.cpp
@@ -1,0 +1,43 @@
+#include "alloc_tracker.h"
+#include <lora_phy/phy.hpp>
+#include <complex>
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+int main() {
+    const unsigned sf = 7;
+    const size_t symbol_count = 4;
+    const size_t samples_per_symbol = size_t(1) << sf;
+    const size_t sample_count = symbol_count * samples_per_symbol;
+
+    std::vector<uint16_t> symbols(symbol_count, 0);
+    std::vector<std::complex<float>> samples(sample_count);
+
+    {
+        alloc_tracker::Guard guard;
+        lora_phy::lora_modulate(symbols.data(), symbol_count, samples.data(), sf);
+        if (guard.count() != 0) {
+            std::cerr << "Allocation occurred in modulate" << std::endl;
+            return 1;
+        }
+    }
+
+    lora_phy::lora_demod_workspace ws{};
+    lora_phy::lora_demod_init(&ws, sf);
+    std::vector<uint16_t> demod(symbol_count);
+
+    {
+        alloc_tracker::Guard guard;
+        lora_phy::lora_demodulate(&ws, samples.data(), sample_count, demod.data());
+        if (guard.count() != 0) {
+            std::cerr << "Allocation occurred in demodulate" << std::endl;
+            lora_phy::lora_demod_free(&ws);
+            return 1;
+        }
+    }
+
+    lora_phy::lora_demod_free(&ws);
+    std::cout << "No allocations detected" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Provide `alloc_tracker.h` with a global allocation counter
- Add `no_alloc_test` verifying `lora_modulate` and `lora_demodulate` allocate no memory
- Build new test target in CMake

## Testing
- `cmake --build .`
- `./no_alloc_test`
- `./e2e_chain_test`
- `./bit_exact_test` *(fails: Mismatch in profile sf7_bw125_cr45)*


------
https://chatgpt.com/codex/tasks/task_e_68bc76857b60832985a3aa964b7da3ec