### PR TITLE
Add selectable vector dumps and generation script

### DIFF
--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -4,12 +4,24 @@
 The test suite validates the LoRa PHY library for bit accuracy, end-to-end modulation/demodulation, error-rate behaviour and performance.  It ensures typical LoRa profiles work and checks for dynamic allocations.
 
 ## Generating Reference Vectors
-Deterministic vectors are required for regression tests.  Generate them after building the project:
+Deterministic vectors are required for regression tests.  Generate them after
+building the project:
 
 ```bash
-python scripts/generate_vectors.py --sf 7 --seed 1 --out vectors/my_run
+scripts/generate_vectors.sh vectors/my_run
 ```
-The script writes IQ samples and decoded payloads under `vectors/` with a manifest of hashes so they can be regenerated.
+
+The script invokes `lora_phy_vector_dump` with typical parameters (SF7,
+16 payload bytes, seed 1) and writes the selected internal states to the
+provided directory.  Generated files include:
+
+* `payload.bin` – raw payload bytes
+* `pre_interleave.csv` – Hamming encoded codewords (decimal per line)
+* `post_interleave.csv` – symbols after the diagonal interleaver
+* `iq_samples.csv` – complex samples as `real,imag`
+* `demod_symbols.csv` – demodulated symbols
+* `deinterleave.csv` – codewords after deinterleaving
+* `decoded.bin` – final decoded payload
 
 ## Running Tests
 Build the test executables:

--- a/runners/lora_phy_vector_dump.cpp
+++ b/runners/lora_phy_vector_dump.cpp
@@ -1,4 +1,5 @@
 #include <lora_phy/phy.hpp>
+#include <lora_phy/LoRaCodes.hpp>
 #include <vector>
 #include <complex>
 #include <fstream>
@@ -6,12 +7,27 @@
 #include <iostream>
 #include <cstdint>
 #include <cstring>
+#include <set>
+#include <string>
 
+/*
+ * Dump internal LoRa PHY vectors for use in tests.
+ *
+ * Supported dump states and their file formats:
+ *   payload          -> payload.bin (raw bytes)
+ *   pre_interleave   -> pre_interleave.csv (decimal codewords per line)
+ *   post_interleave  -> post_interleave.csv (decimal symbols per line)
+ *   iq               -> iq_samples.csv ("real,imag" per line)
+ *   demod            -> demod_symbols.csv (decimal symbols per line)
+ *   deinterleave     -> deinterleave.csv (decimal codewords per line)
+ *   decoded          -> decoded.bin (raw bytes)
+ */
 int main(int argc, char** argv) {
     unsigned sf = 7;
     unsigned seed = 0;
     size_t byte_count = 16;
     const char* out_dir = nullptr;
+    std::set<std::string> dumps;
 
     for (int i = 1; i < argc; ++i) {
         const char* arg = argv[i];
@@ -19,6 +35,7 @@ int main(int argc, char** argv) {
         else if (std::strncmp(arg, "--seed=", 7) == 0) seed = std::stoul(arg + 7);
         else if (std::strncmp(arg, "--bytes=", 8) == 0) byte_count = std::stoul(arg + 8);
         else if (std::strncmp(arg, "--out=", 6) == 0) out_dir = arg + 6;
+        else if (std::strncmp(arg, "--dump=", 7) == 0) dumps.insert(arg + 7);
         else {
             std::cerr << "Unknown argument: " << arg << std::endl;
             return 1;
@@ -30,17 +47,41 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    if (dumps.empty()) {
+        dumps.insert("payload");
+        dumps.insert("pre_interleave");
+        dumps.insert("post_interleave");
+        dumps.insert("iq");
+        dumps.insert("demod");
+        dumps.insert("deinterleave");
+        dumps.insert("decoded");
+    }
+
     std::mt19937 rng(seed);
     std::uniform_int_distribution<int> dist(0, 255);
     std::vector<uint8_t> payload(byte_count);
     for (size_t i = 0; i < byte_count; i++) payload[i] = static_cast<uint8_t>(dist(rng));
 
-    std::vector<uint16_t> symbols(byte_count * 2);
-    size_t symbol_count = lora_phy::lora_encode(payload.data(), byte_count, symbols.data(), sf);
+    // Encode into codewords (pre-interleave)
+    const size_t nibble_count = byte_count * 2;
+    const size_t cw_count = ((nibble_count + sf - 1) / sf) * sf; // round up to multiple of sf
+    std::vector<uint8_t> pre_interleave(cw_count, 0);
+    for (size_t i = 0; i < nibble_count; i++) {
+        const uint8_t byte = payload[i / 2];
+        const uint8_t nibble = (i & 1) ? (byte & 0x0f) : (byte >> 4);
+        pre_interleave[i] = encodeHamming84sx(nibble);
+    }
+
+    // Interleave into symbols
+    const size_t rdd = 4; // typical redundancy
+    const size_t blocks = cw_count / sf;
+    const size_t symbol_count = blocks * (4 + rdd);
+    std::vector<uint16_t> post_interleave(symbol_count, 0);
+    diagonalInterleaveSx(pre_interleave.data(), cw_count, post_interleave.data(), sf, rdd);
 
     const size_t samples_per_symbol = 1u << sf;
     std::vector<std::complex<float>> samples(symbol_count * samples_per_symbol);
-    size_t sample_count = lora_phy::lora_modulate(symbols.data(), symbol_count, samples.data(), sf);
+    size_t sample_count = lora_phy::lora_modulate(post_interleave.data(), symbol_count, samples.data(), sf);
 
     std::vector<uint16_t> demod(symbol_count);
     lora_phy::lora_demod_workspace demod_ws{};
@@ -48,32 +89,64 @@ int main(int argc, char** argv) {
     lora_phy::lora_demodulate(&demod_ws, samples.data(), sample_count, demod.data());
     lora_phy::lora_demod_free(&demod_ws);
 
+    // Deinterleave and decode
+    std::vector<uint8_t> deinterleave(cw_count, 0);
+    diagonalDeterleaveSx(demod.data(), symbol_count, deinterleave.data(), sf, rdd);
+
     std::vector<uint8_t> decoded(byte_count);
-    lora_phy::lora_decode(demod.data(), symbol_count, decoded.data());
+    for (size_t i = 0; i < byte_count; i++) {
+        bool err = false, bad = false;
+        uint8_t hi = decodeHamming84sx(deinterleave[2 * i], err, bad) & 0x0f;
+        err = bad = false;
+        uint8_t lo = decodeHamming84sx(deinterleave[2 * i + 1], err, bad) & 0x0f;
+        decoded[i] = static_cast<uint8_t>((hi << 4) | lo);
+    }
 
     std::string base(out_dir);
-
     std::ofstream f;
-    f.open(base + "/payload.bin", std::ios::binary);
-    f.write(reinterpret_cast<const char*>(payload.data()), payload.size());
-    f.close();
 
-    f.open(base + "/symbols.csv");
-    for (size_t i = 0; i < symbol_count; i++) f << symbols[i] << "\n";
-    f.close();
+    if (dumps.count("payload")) {
+        f.open(base + "/payload.bin", std::ios::binary);
+        f.write(reinterpret_cast<const char*>(payload.data()), payload.size());
+        f.close();
+    }
 
-    f.open(base + "/iq_samples.csv");
-    for (size_t i = 0; i < sample_count; i++)
-        f << samples[i].real() << "," << samples[i].imag() << "\n";
-    f.close();
+    if (dumps.count("pre_interleave")) {
+        f.open(base + "/pre_interleave.csv");
+        for (size_t i = 0; i < cw_count; i++) f << static_cast<unsigned>(pre_interleave[i]) << "\n";
+        f.close();
+    }
 
-    f.open(base + "/demod_symbols.csv");
-    for (size_t i = 0; i < symbol_count; i++) f << demod[i] << "\n";
-    f.close();
+    if (dumps.count("post_interleave")) {
+        f.open(base + "/post_interleave.csv");
+        for (size_t i = 0; i < symbol_count; i++) f << post_interleave[i] << "\n";
+        f.close();
+    }
 
-    f.open(base + "/decoded.bin", std::ios::binary);
-    f.write(reinterpret_cast<const char*>(decoded.data()), decoded.size());
-    f.close();
+    if (dumps.count("iq")) {
+        f.open(base + "/iq_samples.csv");
+        for (size_t i = 0; i < sample_count; i++)
+            f << samples[i].real() << "," << samples[i].imag() << "\n";
+        f.close();
+    }
+
+    if (dumps.count("demod")) {
+        f.open(base + "/demod_symbols.csv");
+        for (size_t i = 0; i < symbol_count; i++) f << demod[i] << "\n";
+        f.close();
+    }
+
+    if (dumps.count("deinterleave")) {
+        f.open(base + "/deinterleave.csv");
+        for (size_t i = 0; i < cw_count; i++) f << static_cast<unsigned>(deinterleave[i]) << "\n";
+        f.close();
+    }
+
+    if (dumps.count("decoded")) {
+        f.open(base + "/decoded.bin", std::ios::binary);
+        f.write(reinterpret_cast<const char*>(decoded.data()), decoded.size());
+        f.close();
+    }
 
     return 0;
 }

--- a/scripts/generate_vectors.sh
+++ b/scripts/generate_vectors.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUILD_DIR=${BUILD_DIR:-build}
+BIN="$BUILD_DIR/lora_phy_vector_dump"
+OUT_DIR=${1:-vectors/generated}
+
+if [ ! -x "$BIN" ]; then
+    echo "Vector dump binary not found: $BIN" >&2
+    echo "Build the project first (cmake --build $BUILD_DIR)." >&2
+    exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+"$BIN" --sf=7 --seed=1 --bytes=16 --out="$OUT_DIR" \
+    --dump=payload \
+    --dump=pre_interleave \
+    --dump=post_interleave \
+    --dump=iq \
+    --dump=demod \
+    --dump=deinterleave \
+    --dump=decoded
+
+echo "Vectors written to $OUT_DIR"


### PR DESCRIPTION
## Summary
- expose `--dump` options in `lora_phy_vector_dump` to select payload, interleaver, IQ and other states
- document output file formats and add a `generate_vectors.sh` helper script
- update testing guide for on-demand vector generation

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `./build/e2e_chain_test`
- `./build/no_alloc_test`
- `./build/bit_exact_test` *(fails: Mismatch in profile sf7_bw125_cr45)*


------
https://chatgpt.com/codex/tasks/task_e_68bc7fff79288329978bdc54a4c25c1c