### PR TITLE
refactor: clarify public API and helper headers

### DIFF
--- a/include/lora_phy/ChirpGenerator.hpp
+++ b/include/lora_phy/ChirpGenerator.hpp
@@ -6,7 +6,10 @@
 #include <cmath>
 
 /*!
- * Generate a chirp
+ * Generate a chirp into a caller supplied buffer.  `samps` must reference at
+ * least `NN` elements; the function writes the generated complex samples but
+ * never allocates or frees memory.  All buffers remain owned by the caller.
+ *
  * \param [out] samps pointer to the output samples
  * \param N samples per chirp sans the oversampling
  * \param ovs the oversampling size

--- a/include/lora_phy/LoRaCodes.hpp
+++ b/include/lora_phy/LoRaCodes.hpp
@@ -1,5 +1,14 @@
+#pragma once
+
 #include <cstddef>
 #include <cstdint>
+
+/*
+ * Miscellaneous encoding helpers and checksum routines used by the LoRa PHY.
+ * All functions operate on caller supplied buffers and perform transformations
+ * in place.  No dynamic memory is allocated and the caller retains ownership of
+ * all buffers passed in.
+ */
 
 /***********************************************************************
  * Defines

--- a/include/lora_phy/LoRaDetector.hpp
+++ b/include/lora_phy/LoRaDetector.hpp
@@ -1,8 +1,17 @@
 // Copyright (c) 2016-2016 Lime Microsystems
 // SPDX-License-Identifier: BSL-1.0
 
-#include "kissfft.hh"
+#pragma once
+
 #include <complex>
+#include <lora_phy/kissfft.hh>
+
+/**
+ * Lightweight FFT based detector.  The caller supplies the FFT input/output
+ * buffers and the kissfft instance; the class does not allocate or free memory
+ * and merely reads or writes to the provided arrays for the duration of the
+ * call.
+ */
 
 template <typename Type>
 class LoRaDetector

--- a/include/lora_phy/kissfft.hh
+++ b/include/lora_phy/kissfft.hh
@@ -6,8 +6,9 @@
 
 // The implementation below is a minimal subset of KISS FFT adapted for use in
 // fixed-size workspaces. All memory required for the transform is provided by a
-// plan structure containing statically sized arrays. No dynamic allocations are
-// performed during transform calls.
+// plan structure containing statically sized arrays.  Callers are responsible
+// for allocating the plan and the input/output buffers; no dynamic allocations
+// are performed and the library never frees caller owned memory.
 
 namespace kissfft_utils {
 

--- a/include/lora_phy/phy.hpp
+++ b/include/lora_phy/phy.hpp
@@ -1,9 +1,118 @@
+/**
+ * @file phy.hpp
+ * Public facing API for the lightweight LoRa PHY.  All routines operate on a
+ * caller supplied workspace that owns every buffer required by the modem.  The
+ * library never allocates or frees memory on its own; callers retain ownership
+ * of all buffers and plans for the duration of their use.
+ */
 #pragma once
+
 #include <cstddef>
 #include <cstdint>
 #include <complex>
+#include <sys/types.h>
+
 #include <lora_phy/kissfft.hh>
 
+namespace lora_phy {
+
+// ---------------------------------------------------------------------------
+// Helper structures
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration parameters controlling modulation and coding options.  The
+ * caller retains ownership of this structure; the library copies the values at
+ * initialisation time.
+ */
+struct lora_params {
+    unsigned sf{}; ///< Spreading factor
+    unsigned bw{}; ///< Bandwidth index
+    unsigned cr{}; ///< Coding rate index
+};
+
+/**
+ * Metrics collected during demodulation/decoding.  The returned pointer from
+ * get_last_metrics() refers to this structure inside the workspace and remains
+ * valid until the next call that updates it.
+ */
+struct lora_metrics {
+    bool  crc_ok{};      ///< true when last block passed CRC
+    float cfo{};         ///< estimated carrier frequency offset
+    float time_offset{}; ///< estimated timing offset
+};
+
+/**
+ * Runtime workspace owned by the caller.  All buffers referenced here must be
+ * preallocated by the caller before calling init().  The library reads or
+ * writes to these buffers only for the duration of the call and never frees or
+ * reallocates them.
+ */
+struct lora_workspace {
+    uint16_t*            symbol_buf{}; ///< N entries
+    std::complex<float>* fft_in{};     ///< N complex samples
+    std::complex<float>* fft_out{};    ///< N complex samples
+
+    kissfft_plan<float>  plan_fwd{};   ///< forward FFT plan
+    kissfft_plan<float>  plan_inv{};   ///< inverse FFT plan
+
+    lora_metrics         metrics{};    ///< updated by processing functions
+};
+
+// ---------------------------------------------------------------------------
+// High level API
+// ---------------------------------------------------------------------------
+
+/** Initialise the workspace for a given parameter set.  Returns 0 on success
+ * or -EINVAL when parameters are invalid.  The workspace and the buffers it
+ * references are owned by the caller and must remain valid for subsequent
+ * calls. */
+int init(lora_workspace* ws, const lora_params* cfg);
+
+/** Reset runtime counters and metric fields in @p ws without touching the
+ * caller supplied buffers or FFT plans. */
+void reset(lora_workspace* ws);
+
+/** Encode @p payload into @p symbols.  @p symbols must point to a caller
+ * provided buffer of at least @p symbol_cap entries.  Returns the number of
+ * symbols written or -ERANGE if the buffer is too small. */
+ssize_t encode(lora_workspace* ws,
+               const uint8_t* payload, size_t payload_len,
+               uint16_t* symbols, size_t symbol_cap);
+
+/** Decode @p symbols into the caller provided @p payload buffer.  The buffer
+ * must have space for @p payload_cap bytes.  Returns bytes written or a
+ * negative error code on failure. */
+ssize_t decode(lora_workspace* ws,
+               const uint16_t* symbols, size_t symbol_count,
+               uint8_t* payload, size_t payload_cap);
+
+/** Modulate symbols into complex baseband samples.  @p iq must reference a
+ * buffer with capacity for @p symbol_count * (1<<sf) samples.  The function
+ * returns the number of samples produced or -ERANGE if @p iq_cap is
+ * insufficient. */
+ssize_t modulate(lora_workspace* ws,
+                 const uint16_t* symbols, size_t symbol_count,
+                 std::complex<float>* iq, size_t iq_cap);
+
+/** Demodulate @p iq samples into @p symbols using the FFT plans inside @p ws.
+ * The input length must be a multiple of the symbol size.  Returns number of
+ * symbols produced or a negative error code. */
+ssize_t demodulate(lora_workspace* ws,
+                   const std::complex<float>* iq, size_t sample_count,
+                   uint16_t* symbols, size_t symbol_cap);
+
+/** Obtain metrics from the last decode or demodulate call.  The returned
+ * pointer refers to memory inside @p ws and must not be freed by the caller. */
+const lora_metrics* get_last_metrics(const lora_workspace* ws);
+
+// ---------------------------------------------------------------------------
+// Legacy helpers
+// ---------------------------------------------------------------------------
+
+} // namespace lora_phy
+
+// Forward declaration of the legacy detector in the global namespace.
 template <typename T> class LoRaDetector;
 
 namespace lora_phy {
@@ -18,7 +127,7 @@ struct lora_demod_workspace {
     LoRaDetector<float>* detector{};
 };
 
-// Initialize and clean up the demodulator workspace.
+// Initialise and clean up the demodulator workspace.
 void lora_demod_init(lora_demod_workspace* ws, unsigned sf);
 void lora_demod_free(lora_demod_workspace* ws);
 


### PR DESCRIPTION
## Summary
- expose high-level LoRa PHY API with workspace-based ownership rules
- ensure helper headers are self-contained and includeable via `<lora_phy/...>`
- document buffer ownership contracts across helper headers

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `./build/bit_exact_test` *(fails: mismatch in profile sf7_bw125_cr45)*
- `./build/e2e_chain_test`
- `./build/no_alloc_test`


------
https://chatgpt.com/codex/tasks/task_e_68bc878d692c8329b503cb6a56d29df7