### PR TITLE
Add runnable examples and vector dump for LoRa PHY API

### DIFF
--- a/runners/lora_phy_vector_dump.cpp
+++ b/runners/lora_phy_vector_dump.cpp
@@ -1,100 +1,132 @@
 #include <lora_phy/phy.hpp>
 #include <lora_phy/LoRaCodes.hpp>
-#include <vector>
+
 #include <complex>
-#include <fstream>
-#include <random>
-#include <iostream>
 #include <cstdint>
-#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <random>
 #include <set>
 #include <string>
+#include <vector>
 
-/*
- * Dump internal LoRa PHY vectors for use in tests.
- *
- * Supported dump states and their file formats:
- *   payload          -> payload.bin (raw bytes)
- *   pre_interleave   -> pre_interleave.csv (decimal codewords per line)
- *   post_interleave  -> post_interleave.csv (decimal symbols per line)
- *   iq               -> iq_samples.csv ("real,imag" per line)
- *   demod            -> demod_symbols.csv (decimal symbols per line)
- *   deinterleave     -> deinterleave.csv (decimal codewords per line)
- *   decoded          -> decoded.bin (raw bytes)
- */
+using namespace lora_phy;
+
+namespace {
+
+void usage(const char* prog) {
+    std::cerr << "Usage: " << prog
+              << " --out=DIR [--sf=N] [--bytes=N] [--seed=N]"
+              << " [--dump=STAGE,...]\n";
+}
+
+} // namespace
+
 int main(int argc, char** argv) {
     unsigned sf = 7;
-    unsigned seed = 0;
+    unsigned seed = 1;
     size_t byte_count = 16;
-    const char* out_dir = nullptr;
+    std::string out_dir;
     std::set<std::string> dumps;
 
     for (int i = 1; i < argc; ++i) {
-        const char* arg = argv[i];
-        if (std::strncmp(arg, "--sf=", 5) == 0) sf = std::stoul(arg + 5);
-        else if (std::strncmp(arg, "--seed=", 7) == 0) seed = std::stoul(arg + 7);
-        else if (std::strncmp(arg, "--bytes=", 8) == 0) byte_count = std::stoul(arg + 8);
-        else if (std::strncmp(arg, "--out=", 6) == 0) out_dir = arg + 6;
-        else if (std::strncmp(arg, "--dump=", 7) == 0) dumps.insert(arg + 7);
-        else {
-            std::cerr << "Unknown argument: " << arg << std::endl;
+        std::string arg = argv[i];
+        if (arg.rfind("--sf=", 0) == 0) {
+            sf = static_cast<unsigned>(std::stoul(arg.substr(5)));
+        } else if (arg.rfind("--seed=", 0) == 0) {
+            seed = static_cast<unsigned>(std::stoul(arg.substr(7)));
+        } else if (arg.rfind("--bytes=", 0) == 0) {
+            byte_count = static_cast<size_t>(std::stoul(arg.substr(8)));
+        } else if (arg.rfind("--out=", 0) == 0) {
+            out_dir = arg.substr(6);
+        } else if (arg.rfind("--dump=", 0) == 0) {
+            dumps.insert(arg.substr(7));
+        } else if (arg == "--help" || arg == "-h") {
+            usage(argv[0]);
+            return 0;
+        } else {
+            std::cerr << "Unknown argument: " << arg << "\n";
+            usage(argv[0]);
             return 1;
         }
     }
 
-    if (!out_dir) {
-        std::cerr << "--out argument is required" << std::endl;
+    if (out_dir.empty()) {
+        usage(argv[0]);
         return 1;
     }
 
     if (dumps.empty()) {
-        dumps.insert("payload");
-        dumps.insert("pre_interleave");
-        dumps.insert("post_interleave");
-        dumps.insert("iq");
-        dumps.insert("demod");
-        dumps.insert("deinterleave");
-        dumps.insert("decoded");
+        dumps = {"payload",      "pre_interleave", "post_interleave",
+                 "iq",           "demod",          "deinterleave",
+                 "decoded"};
     }
 
     std::mt19937 rng(seed);
     std::uniform_int_distribution<int> dist(0, 255);
     std::vector<uint8_t> payload(byte_count);
-    for (size_t i = 0; i < byte_count; i++) payload[i] = static_cast<uint8_t>(dist(rng));
+    for (size_t i = 0; i < byte_count; ++i)
+        payload[i] = static_cast<uint8_t>(dist(rng));
 
-    // Encode into codewords (pre-interleave)
     const size_t nibble_count = byte_count * 2;
-    const size_t cw_count = ((nibble_count + sf - 1) / sf) * sf; // round up to multiple of sf
-    std::vector<uint8_t> pre_interleave(cw_count, 0);
-    for (size_t i = 0; i < nibble_count; i++) {
-        const uint8_t byte = payload[i / 2];
-        const uint8_t nibble = (i & 1) ? (byte & 0x0f) : (byte >> 4);
-        pre_interleave[i] = encodeHamming84sx(nibble);
-    }
-
-    // Interleave into symbols
-    const size_t rdd = 4; // typical redundancy
+    const size_t cw_count = ((nibble_count + sf - 1) / sf) * sf;
+    const size_t rdd = 4;
     const size_t blocks = cw_count / sf;
     const size_t symbol_count = blocks * (4 + rdd);
-    std::vector<uint16_t> post_interleave(symbol_count, 0);
-    diagonalInterleaveSx(pre_interleave.data(), cw_count, post_interleave.data(), sf, rdd);
+    const size_t N = size_t(1) << sf;
 
-    const size_t samples_per_symbol = 1u << sf;
-    std::vector<std::complex<float>> samples(symbol_count * samples_per_symbol);
-    size_t sample_count = lora_phy::lora_modulate(post_interleave.data(), symbol_count, samples.data(), sf);
+    std::vector<uint8_t> pre_interleave(cw_count, 0);
+    for (size_t i = 0; i < nibble_count; ++i) {
+        uint8_t b = payload[i / 2];
+        uint8_t nib = (i & 1) ? (b & 0x0f) : (b >> 4);
+        pre_interleave[i] = encodeHamming84sx(nib);
+    }
 
+    std::vector<uint16_t> post_interleave(symbol_count);
     std::vector<uint16_t> demod(symbol_count);
-    lora_phy::lora_demod_workspace demod_ws{};
-    lora_phy::lora_demod_init(&demod_ws, sf);
-    lora_phy::lora_demodulate(&demod_ws, samples.data(), sample_count, demod.data());
-    lora_phy::lora_demod_free(&demod_ws);
-
-    // Deinterleave and decode
     std::vector<uint8_t> deinterleave(cw_count, 0);
-    diagonalDeterleaveSx(demod.data(), symbol_count, deinterleave.data(), sf, rdd);
-
     std::vector<uint8_t> decoded(byte_count);
-    for (size_t i = 0; i < byte_count; i++) {
+    std::vector<std::complex<float>> fft_in(N), fft_out(N);
+    std::vector<std::complex<float>> samples(symbol_count * N);
+
+    lora_workspace ws{};
+    ws.symbol_buf = post_interleave.data();
+    ws.fft_in = fft_in.data();
+    ws.fft_out = fft_out.data();
+    lora_params params{};
+    params.sf = sf;
+    params.bw = 0;
+    params.cr = 0;
+    if (init(&ws, &params) != 0) {
+        std::cerr << "Failed to initialise workspace\n";
+        return 1;
+    }
+
+    ssize_t produced = encode(&ws, payload.data(), payload.size(),
+                              post_interleave.data(), post_interleave.size());
+    if (produced < 0) {
+        std::cerr << "encode() failed\n";
+        return 1;
+    }
+
+    ssize_t sample_count = modulate(&ws, post_interleave.data(), produced,
+                                    samples.data(), samples.size());
+    if (sample_count < 0) {
+        std::cerr << "modulate() failed\n";
+        return 1;
+    }
+
+    ssize_t demod_syms = demodulate(&ws, samples.data(), sample_count,
+                                    demod.data(), demod.size());
+    if (demod_syms < 0) {
+        std::cerr << "demodulate() failed\n";
+        return 1;
+    }
+
+    diagonalDeterleaveSx(demod.data(), symbol_count, deinterleave.data(), sf,
+                         rdd);
+
+    for (size_t i = 0; i < byte_count; ++i) {
         bool err = false, bad = false;
         uint8_t hi = decodeHamming84sx(deinterleave[2 * i], err, bad) & 0x0f;
         err = bad = false;
@@ -102,48 +134,43 @@ int main(int argc, char** argv) {
         decoded[i] = static_cast<uint8_t>((hi << 4) | lo);
     }
 
-    std::string base(out_dir);
     std::ofstream f;
 
     if (dumps.count("payload")) {
-        f.open(base + "/payload.bin", std::ios::binary);
+        f.open(out_dir + "/payload.bin", std::ios::binary);
         f.write(reinterpret_cast<const char*>(payload.data()), payload.size());
         f.close();
     }
-
     if (dumps.count("pre_interleave")) {
-        f.open(base + "/pre_interleave.csv");
-        for (size_t i = 0; i < cw_count; i++) f << static_cast<unsigned>(pre_interleave[i]) << "\n";
+        f.open(out_dir + "/pre_interleave.csv");
+        for (size_t i = 0; i < cw_count; ++i)
+            f << static_cast<unsigned>(pre_interleave[i]) << "\n";
         f.close();
     }
-
     if (dumps.count("post_interleave")) {
-        f.open(base + "/post_interleave.csv");
-        for (size_t i = 0; i < symbol_count; i++) f << post_interleave[i] << "\n";
+        f.open(out_dir + "/post_interleave.csv");
+        for (size_t i = 0; i < symbol_count; ++i) f << post_interleave[i] << "\n";
         f.close();
     }
-
     if (dumps.count("iq")) {
-        f.open(base + "/iq_samples.csv");
-        for (size_t i = 0; i < sample_count; i++)
+        f.open(out_dir + "/iq_samples.csv");
+        for (ssize_t i = 0; i < sample_count; ++i)
             f << samples[i].real() << "," << samples[i].imag() << "\n";
         f.close();
     }
-
     if (dumps.count("demod")) {
-        f.open(base + "/demod_symbols.csv");
-        for (size_t i = 0; i < symbol_count; i++) f << demod[i] << "\n";
+        f.open(out_dir + "/demod_symbols.csv");
+        for (size_t i = 0; i < symbol_count; ++i) f << demod[i] << "\n";
         f.close();
     }
-
     if (dumps.count("deinterleave")) {
-        f.open(base + "/deinterleave.csv");
-        for (size_t i = 0; i < cw_count; i++) f << static_cast<unsigned>(deinterleave[i]) << "\n";
+        f.open(out_dir + "/deinterleave.csv");
+        for (size_t i = 0; i < cw_count; ++i)
+            f << static_cast<unsigned>(deinterleave[i]) << "\n";
         f.close();
     }
-
     if (dumps.count("decoded")) {
-        f.open(base + "/decoded.bin", std::ios::binary);
+        f.open(out_dir + "/decoded.bin", std::ios::binary);
         f.write(reinterpret_cast<const char*>(decoded.data()), decoded.size());
         f.close();
     }

--- a/runners/rx_runner.cpp
+++ b/runners/rx_runner.cpp
@@ -1,103 +1,54 @@
 #include <lora_phy/phy.hpp>
-#include <lora_phy/LoRaCodes.hpp>
-#include <vector>
+
 #include <complex>
 #include <cstdint>
-#include <cstring>
-#include <iostream>
 #include <fstream>
 #include <iomanip>
+#include <iostream>
 #include <string>
+#include <vector>
 
-struct lora_params {
-    unsigned sf = 7;
-    unsigned bw = 0;
-    unsigned cr = 0;
-};
+using namespace lora_phy;
 
-struct lora_metrics {
-    bool crc_ok{};
-    float cfo{};
-    float time_offset{};
-};
+namespace {
 
-struct lora_workspace {
-    uint16_t* symbol_buf{};
-    std::complex<float>* fft_in{};
-    std::complex<float>* fft_out{};
-    lora_params params{};
-    lora_metrics metrics{};
-};
-
-static int init(struct lora_workspace* ws, const struct lora_params* cfg) {
-    if (!ws || !cfg) return -1;
-    ws->params = *cfg;
-    ws->metrics = {};
-    return 0;
+void usage(const char* prog) {
+    std::cerr << "Usage: " << prog
+              << " [--in=FILE] [--sf=N] [--cr=N]\n";
+    std::cerr << "Input samples are float32 IQ pairs" << std::endl;
 }
 
-static ssize_t demodulate(struct lora_workspace* ws,
-                          const std::complex<float>* iq, size_t sample_count,
-                          uint16_t* symbols, size_t symbol_cap) {
-    if (!ws || !iq || !symbols) return -1;
-    size_t N = size_t(1) << ws->params.sf;
-    if (sample_count % N != 0) return -1;
-    size_t expected = sample_count / N;
-    if (expected > symbol_cap) return -1;
-    lora_phy::lora_demod_workspace demod_ws{};
-    lora_phy::lora_demod_init(&demod_ws, ws->params.sf);
-    size_t produced = lora_phy::lora_demodulate(&demod_ws, iq, sample_count, symbols);
-    lora_phy::lora_demod_free(&demod_ws);
-    ws->metrics.cfo = 0.0f;
-    ws->metrics.time_offset = 0.0f;
-    return static_cast<ssize_t>(produced);
-}
-
-static ssize_t decode(struct lora_workspace* ws,
-                      const uint16_t* symbols, size_t symbol_count,
-                      uint8_t* payload, size_t payload_cap) {
-    if (!ws || !symbols || !payload) return -1;
-    size_t produced = lora_phy::lora_decode(symbols, symbol_count, payload);
-    if (produced > payload_cap) return -1;
-    // compute CRC if possible: expect last two bytes to contain CRC
-    if (produced >= 4) {
-        size_t data_len = produced - 4; // exclude header(2) and crc(2)
-        uint16_t provided_crc = payload[produced - 2] | (payload[produced - 1] << 8);
-        uint16_t calc_crc = sx1272DataChecksum(payload + 2, data_len);
-        ws->metrics.crc_ok = (provided_crc == calc_crc);
-    } else {
-        ws->metrics.crc_ok = false;
-    }
-    return static_cast<ssize_t>(produced);
-}
-
-static const lora_metrics* get_last_metrics(const lora_workspace* ws) {
-    if (!ws) return nullptr;
-    return &ws->metrics;
-}
+} // namespace
 
 int main(int argc, char** argv) {
-    const char* in_path = nullptr;
+    std::string in_path;
     lora_params params{};
+    params.sf = 7; // defaults
 
     for (int i = 1; i < argc; ++i) {
-        const char* arg = argv[i];
-        if (std::strncmp(arg, "--in=", 5) == 0) in_path = arg + 5;
-        else if (std::strncmp(arg, "--sf=", 5) == 0) params.sf = std::stoul(arg + 5);
-        else if (std::strncmp(arg, "--bw=", 5) == 0) params.bw = std::stoul(arg + 5);
-        else if (std::strncmp(arg, "--cr=", 5) == 0) params.cr = std::stoul(arg + 5);
-        else {
-            std::cerr << "Unknown argument: " << arg << std::endl;
+        std::string arg = argv[i];
+        if (arg.rfind("--in=", 0) == 0) {
+            in_path = arg.substr(5);
+        } else if (arg.rfind("--sf=", 0) == 0) {
+            params.sf = static_cast<unsigned>(std::stoul(arg.substr(5)));
+        } else if (arg.rfind("--cr=", 0) == 0) {
+            params.cr = static_cast<unsigned>(std::stoul(arg.substr(5)));
+        } else if (arg == "--help" || arg == "-h") {
+            usage(argv[0]);
+            return 0;
+        } else {
+            std::cerr << "Unknown argument: " << arg << "\n";
+            usage(argv[0]);
             return 1;
         }
     }
 
     std::istream* in_stream = nullptr;
     std::ifstream file_stream;
-    if (in_path) {
+    if (!in_path.empty()) {
         file_stream.open(in_path, std::ios::binary);
         if (!file_stream) {
-            std::cerr << "Failed to open input file" << std::endl;
+            std::cerr << "Unable to open input file\n";
             return 1;
         }
         in_stream = &file_stream;
@@ -113,16 +64,16 @@ int main(int argc, char** argv) {
     }
 
     if (samples.empty()) {
-        std::cerr << "No samples read" << std::endl;
+        std::cerr << "No samples provided\n";
         return 1;
     }
 
-    size_t N = size_t(1) << params.sf;
+    const size_t N = size_t(1) << params.sf;
     if (samples.size() % N != 0) {
-        std::cerr << "Sample count not multiple of symbol size" << std::endl;
+        std::cerr << "Sample count not multiple of symbol size\n";
         return 1;
     }
-    size_t symbol_count = samples.size() / N;
+    const size_t symbol_count = samples.size() / N;
 
     std::vector<uint16_t> symbols(symbol_count);
     std::vector<std::complex<float>> fft_in(N);
@@ -134,44 +85,38 @@ int main(int argc, char** argv) {
     ws.fft_out = fft_out.data();
 
     if (init(&ws, &params) != 0) {
-        std::cerr << "init failed" << std::endl;
+        std::cerr << "Failed to initialise workspace\n";
         return 1;
     }
 
-    ssize_t demod_syms = demodulate(&ws, samples.data(), samples.size(), ws.symbol_buf, symbol_count);
+    ssize_t demod_syms = demodulate(&ws, samples.data(), samples.size(),
+                                    symbols.data(), symbols.size());
     if (demod_syms < 0) {
-        std::cerr << "demodulate failed" << std::endl;
+        std::cerr << "demodulate() failed\n";
         return 1;
     }
 
-    std::vector<uint8_t> decoded(symbol_count / 2);
-    ssize_t decoded_bytes = decode(&ws, ws.symbol_buf, demod_syms, decoded.data(), decoded.size());
+    std::vector<uint8_t> decoded(demod_syms / 2);
+    ssize_t decoded_bytes =
+        decode(&ws, symbols.data(), demod_syms, decoded.data(), decoded.size());
     if (decoded_bytes < 0) {
-        std::cerr << "decode failed" << std::endl;
+        std::cerr << "decode() failed\n";
         return 1;
     }
 
     const lora_metrics* m = get_last_metrics(&ws);
 
-    if (decoded_bytes >= 2) {
-        uint8_t length_field = decoded[0];
-        uint8_t header_field = decoded[1];
-        std::cout << "Header length=" << static_cast<unsigned>(length_field)
-                  << " header=" << static_cast<unsigned>(header_field) << std::endl;
-        std::cout << "Payload: ";
-        for (ssize_t i = 2; i < decoded_bytes - 2; ++i) {
-            std::cout << std::hex << std::setw(2) << std::setfill('0')
-                      << static_cast<unsigned>(decoded[i]);
-        }
-        std::cout << std::dec << std::endl;
-    } else {
-        std::cout << "Decoded payload too short" << std::endl;
+    std::cout << "Payload: ";
+    for (ssize_t i = 0; i < decoded_bytes; ++i) {
+        std::cout << std::hex << std::setw(2) << std::setfill('0')
+                  << static_cast<unsigned>(decoded[i]);
     }
+    std::cout << std::dec << "\n";
 
     if (m) {
-        std::cout << "CRC OK: " << (m->crc_ok ? "yes" : "no") << std::endl;
-        std::cout << "CFO: " << m->cfo << std::endl;
-        std::cout << "Time offset: " << m->time_offset << std::endl;
+        std::cout << "CRC OK: " << (m->crc_ok ? "yes" : "no") << "\n";
+        std::cout << "CFO: " << m->cfo << "\n";
+        std::cout << "Time offset: " << m->time_offset << "\n";
     }
 
     return 0;

--- a/runners/tx_runner.cpp
+++ b/runners/tx_runner.cpp
@@ -1,94 +1,80 @@
 #include <lora_phy/phy.hpp>
-#include <vector>
+
 #include <complex>
 #include <cstdint>
-#include <cstring>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <string>
-#include <sys/types.h>
+#include <vector>
 
-struct lora_params {
-    unsigned sf = 7;
-    unsigned bw = 0;
-    unsigned cr = 0;
-};
+using namespace lora_phy;
 
-struct lora_workspace {
-    uint16_t* symbol_buf{};
-    std::complex<float>* fft_in{};
-    std::complex<float>* fft_out{};
-    lora_params params{};
-};
+namespace {
 
-static int init(struct lora_workspace* ws, const struct lora_params* cfg) {
-    if (!ws || !cfg) return -1;
-    ws->params = *cfg;
-    return 0;
+void usage(const char* prog) {
+    std::cerr << "Usage: " << prog
+              << " --payload=HEX [--sf=N] [--cr=N] [--out=FILE|--stdout]\n";
 }
 
-static ssize_t encode(struct lora_workspace* ws,
-                      const uint8_t* payload, size_t payload_len,
-                      uint16_t* symbols, size_t symbol_cap) {
-    if (!ws || !payload || !symbols) return -1;
-    size_t produced = lora_phy::lora_encode(payload, payload_len, symbols, ws->params.sf);
-    if (produced > symbol_cap) return -1;
-    return static_cast<ssize_t>(produced);
+bool parse_hex_payload(const std::string& hex, std::vector<uint8_t>& out) {
+    if (hex.size() % 2 != 0) return false;
+    out.clear();
+    out.reserve(hex.size() / 2);
+    for (size_t i = 0; i < hex.size(); i += 2) {
+        const std::string byte_str = hex.substr(i, 2);
+        out.push_back(static_cast<uint8_t>(std::stoul(byte_str, nullptr, 16)));
+    }
+    return true;
 }
 
-static ssize_t modulate(struct lora_workspace* ws,
-                        const uint16_t* symbols, size_t symbol_count,
-                        std::complex<float>* iq, size_t iq_cap) {
-    if (!ws || !symbols || !iq) return -1;
-    size_t produced = lora_phy::lora_modulate(symbols, symbol_count, iq, ws->params.sf);
-    if (produced > iq_cap) return -1;
-    return static_cast<ssize_t>(produced);
-}
+} // namespace
 
 int main(int argc, char** argv) {
-    const char* payload_hex = nullptr;
-    lora_params params{};
-    const char* out_path = nullptr;
+    std::string payload_hex;
+    std::string out_path;
     bool to_stdout = false;
+    lora_params params{};
+    params.sf = 7; // defaults
 
     for (int i = 1; i < argc; ++i) {
-        const char* arg = argv[i];
-        if (std::strncmp(arg, "--payload=", 10) == 0) payload_hex = arg + 10;
-        else if (std::strncmp(arg, "--sf=", 5) == 0) params.sf = std::stoul(arg + 5);
-        else if (std::strncmp(arg, "--bw=", 5) == 0) params.bw = std::stoul(arg + 5);
-        else if (std::strncmp(arg, "--cr=", 5) == 0) params.cr = std::stoul(arg + 5);
-        else if (std::strncmp(arg, "--out=", 6) == 0) out_path = arg + 6;
-        else if (std::strcmp(arg, "--stdout") == 0) to_stdout = true;
-        else {
-            std::cerr << "Unknown argument: " << arg << std::endl;
+        std::string arg = argv[i];
+        if (arg.rfind("--payload=", 0) == 0) {
+            payload_hex = arg.substr(10);
+        } else if (arg.rfind("--sf=", 0) == 0) {
+            params.sf = static_cast<unsigned>(std::stoul(arg.substr(5)));
+        } else if (arg.rfind("--cr=", 0) == 0) {
+            params.cr = static_cast<unsigned>(std::stoul(arg.substr(5)));
+        } else if (arg.rfind("--out=", 0) == 0) {
+            out_path = arg.substr(6);
+        } else if (arg == "--stdout") {
+            to_stdout = true;
+        } else if (arg == "--help" || arg == "-h") {
+            usage(argv[0]);
+            return 0;
+        } else {
+            std::cerr << "Unknown argument: " << arg << "\n";
+            usage(argv[0]);
             return 1;
         }
     }
 
-    if (!payload_hex) {
-        std::cerr << "--payload argument is required" << std::endl;
+    if (payload_hex.empty()) {
+        usage(argv[0]);
         return 1;
     }
-    if (!to_stdout && !out_path) {
-        std::cerr << "Specify --out=<path> or --stdout" << std::endl;
-        return 1;
-    }
-
-    size_t hex_len = std::strlen(payload_hex);
-    if (hex_len % 2 != 0) {
-        std::cerr << "Payload hex must have even length" << std::endl;
+    if (!to_stdout && out_path.empty()) {
+        std::cerr << "Specify --out=FILE or --stdout\n";
         return 1;
     }
 
     std::vector<uint8_t> payload;
-    payload.reserve(hex_len / 2);
-    for (size_t i = 0; i < hex_len; i += 2) {
-        std::string byte_str(payload_hex + i, 2);
-        payload.push_back(static_cast<uint8_t>(std::stoul(byte_str, nullptr, 16)));
+    if (!parse_hex_payload(payload_hex, payload)) {
+        std::cerr << "Invalid payload hex string\n";
+        return 1;
     }
 
-    const size_t symbol_cap = payload.size() * 2; // Hamming(8,4) -> 2 symbols per byte
-    const size_t N = size_t(1) << params.sf;      // samples per symbol
+    const size_t symbol_cap = payload.size() * 2; // Hamming(8,4)
+    const size_t N = size_t(1) << params.sf;
 
     std::vector<uint16_t> symbols(symbol_cap);
     std::vector<std::complex<float>> fft_in(N);
@@ -100,20 +86,22 @@ int main(int argc, char** argv) {
     ws.fft_out = fft_out.data();
 
     if (init(&ws, &params) != 0) {
-        std::cerr << "init failed" << std::endl;
+        std::cerr << "Failed to initialise workspace\n";
         return 1;
     }
 
-    ssize_t symbol_count = encode(&ws, payload.data(), payload.size(), ws.symbol_buf, symbol_cap);
+    ssize_t symbol_count = encode(&ws, payload.data(), payload.size(),
+                                  symbols.data(), symbols.size());
     if (symbol_count < 0) {
-        std::cerr << "encode failed" << std::endl;
+        std::cerr << "encode() failed\n";
         return 1;
     }
 
     std::vector<std::complex<float>> iq(symbol_count * N);
-    ssize_t sample_count = modulate(&ws, ws.symbol_buf, symbol_count, iq.data(), iq.size());
+    ssize_t sample_count =
+        modulate(&ws, symbols.data(), symbol_count, iq.data(), iq.size());
     if (sample_count < 0) {
-        std::cerr << "modulate failed" << std::endl;
+        std::cerr << "modulate() failed\n";
         return 1;
     }
 
@@ -124,20 +112,20 @@ int main(int argc, char** argv) {
     } else {
         file_stream.open(out_path, std::ios::binary);
         if (!file_stream) {
-            std::cerr << "Failed to open output file" << std::endl;
+            std::cerr << "Unable to open output file\n";
             return 1;
         }
         out_stream = &file_stream;
     }
 
     for (ssize_t i = 0; i < sample_count; ++i) {
-        float re = iq[i].real();
-        float im = iq[i].imag();
+        const float re = iq[i].real();
+        const float im = iq[i].imag();
         out_stream->write(reinterpret_cast<const char*>(&re), sizeof(float));
         out_stream->write(reinterpret_cast<const char*>(&im), sizeof(float));
     }
 
-    if (file_stream) file_stream.close();
+    if (file_stream.is_open()) file_stream.close();
     return 0;
 }
 

--- a/src/phy/phy.cpp
+++ b/src/phy/phy.cpp
@@ -1,0 +1,105 @@
+#include <lora_phy/phy.hpp>
+#include <lora_phy/LoRaCodes.hpp>
+#include <lora_phy/LoRaDetector.hpp>
+#include <lora_phy/ChirpGenerator.hpp>
+
+#include <cmath>
+
+namespace lora_phy {
+
+namespace {
+
+static unsigned deduce_sf(const lora_workspace* ws) {
+    unsigned sf = 0;
+    size_t n = static_cast<size_t>(ws->plan_fwd.nfft);
+    while ((size_t(1) << sf) < n) ++sf;
+    return sf;
+}
+
+} // namespace
+
+int init(lora_workspace* ws, const lora_params* cfg) {
+    if (!ws || !cfg) return -1;
+    const int N = 1 << cfg->sf;
+    kissfft<float>::init(ws->plan_fwd, N, false);
+    kissfft<float>::init(ws->plan_inv, N, true);
+    ws->metrics = {};
+    return 0;
+}
+
+void reset(lora_workspace* ws) {
+    if (ws) ws->metrics = {};
+}
+
+ssize_t encode(lora_workspace* ws,
+               const uint8_t* payload, size_t payload_len,
+               uint16_t* symbols, size_t symbol_cap) {
+    if (!ws || !payload || !symbols) return -1;
+    unsigned sf = deduce_sf(ws);
+    size_t produced = lora_encode(payload, payload_len, symbols, sf);
+    if (produced > symbol_cap) return -1;
+    return static_cast<ssize_t>(produced);
+}
+
+ssize_t modulate(lora_workspace* ws,
+                 const uint16_t* symbols, size_t symbol_count,
+                 std::complex<float>* iq, size_t iq_cap) {
+    if (!ws || !symbols || !iq) return -1;
+    unsigned sf = deduce_sf(ws);
+    size_t produced = lora_modulate(symbols, symbol_count, iq, sf);
+    if (produced > iq_cap) return -1;
+    return static_cast<ssize_t>(produced);
+}
+
+ssize_t demodulate(lora_workspace* ws,
+                   const std::complex<float>* iq, size_t sample_count,
+                   uint16_t* symbols, size_t symbol_cap) {
+    if (!ws || !iq || !symbols) return -1;
+    unsigned sf = deduce_sf(ws);
+    size_t N = size_t(1) << sf;
+    if (sample_count % N != 0) return -1;
+    size_t num_symbols = sample_count / N;
+    if (num_symbols > symbol_cap) return -1;
+
+    kissfft<float> fft(ws->plan_fwd);
+    LoRaDetector<float> detector(N, ws->fft_in, ws->fft_out, fft);
+    for (size_t s = 0; s < num_symbols; ++s) {
+        float phase = 0.0f;
+        genChirp(ws->fft_out, static_cast<int>(N), 1, static_cast<int>(N),
+                 0.0f, true, 1.0f, phase);
+        const std::complex<float>* sym = iq + s * N;
+        for (size_t i = 0; i < N; ++i)
+            detector.feed(i, sym[i] * ws->fft_out[i]);
+        float p, pav, findex;
+        size_t idx = detector.detect(p, pav, findex);
+        symbols[s] = static_cast<uint16_t>(idx);
+    }
+    ws->metrics.cfo = 0.0f;
+    ws->metrics.time_offset = 0.0f;
+    return static_cast<ssize_t>(num_symbols);
+}
+
+ssize_t decode(lora_workspace* ws,
+               const uint16_t* symbols, size_t symbol_count,
+               uint8_t* payload, size_t payload_cap) {
+    if (!ws || !symbols || !payload) return -1;
+    size_t produced = lora_decode(symbols, symbol_count, payload);
+    if (produced > payload_cap) return -1;
+    if (produced >= 4) {
+        size_t data_len = produced - 4;
+        uint16_t provided = payload[produced - 2] | (payload[produced - 1] << 8);
+        uint16_t calc = sx1272DataChecksum(payload + 2, data_len);
+        ws->metrics.crc_ok = (provided == calc);
+    } else {
+        ws->metrics.crc_ok = false;
+    }
+    return static_cast<ssize_t>(produced);
+}
+
+const lora_metrics* get_last_metrics(const lora_workspace* ws) {
+    if (!ws) return nullptr;
+    return &ws->metrics;
+}
+
+} // namespace lora_phy
+


### PR DESCRIPTION
## Summary
- Implement public API wrappers for LoRa PHY workspace (init/reset/encode/decode/modulate/demodulate)
- Provide tx and rx runners that use the new API and parse simple command-line parameters
- Add vector dump utility to emit intermediate states for debugging

## Testing
- `cmake --build build`
- `./build/e2e_chain_test`
- `./build/no_alloc_test`
- `./build/bit_exact_test` *(fails: mismatch in profile sf7_bw125_cr45)*

------
https://chatgpt.com/codex/tasks/task_e_68bc894106b08329ad5b442e5d567073