### PR TITLE
Add bandwidth enumeration and chirp scaling

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -22,6 +22,7 @@ struct lora_workspace {
 
     struct lora_metrics metrics; /* updated by processing functions */
     unsigned       osr;          /* oversampling ratio */
+    enum bandwidth bw;           /* operating bandwidth */
 };
 ```
 
@@ -34,11 +35,15 @@ All routines return `0` on success or a negative error code (`-EINVAL`,
 `-ERANGE`, …) on failure unless noted otherwise.  Output functions return the
 number of elements written when successful.
 
+The `bandwidth` enumeration defines the supported LoRa bandwidths and
+currently allows `bw_125` (125 kHz), `bw_250` (250 kHz) and `bw_500`
+(500 kHz).
+
 ### `int init(struct lora_workspace *ws, const struct lora_params *cfg);`
 Initializes the workspace for a given set of parameters.
 
 * `ws` – workspace to populate. Must reference valid buffers.
-* `cfg` – modulation and coding parameters (spread factor, coding rate, oversampling, etc.).
+* `cfg` – modulation and coding parameters (spread factor, bandwidth, coding rate, oversampling, etc.).
 * Returns `0` on success or `-EINVAL` if parameters are invalid.
 
 ### `void reset(struct lora_workspace *ws);`

--- a/PORTING_NOTES.md
+++ b/PORTING_NOTES.md
@@ -2,13 +2,16 @@
 
 This document summarizes core functions, dependencies, and allocation models for selected modules in the LoRa SDR lightweight library.
 
+The PHY supports bandwidths of 125, 250 and 500 kHz selectable via the
+`bandwidth` enumeration in `lora_params`.
+
 | Module | Core Functions | Dependencies | Allocation Model | Notes |
 | --- | --- | --- | --- | --- |
 | `LoRaMod.cpp` | `LoRaMod::work` | Pothos framework (`Pothos::Block`, `Pothos::BufferChunk`, labels) | Uses `Pothos::BufferChunk` for payload; generates chirps in-place | Pothos block wrapper; no Poco/JSON |
 | `LoRaDemod.cpp` | `LoRaDemod::work` | Pothos framework, `LoRaDetector` (FFT via kissfft) | Output via `Pothos::BufferChunk`; uses `std::vector` for chirp tables | Pothos block wrapper; no Poco/JSON |
 | `LoRaEncoder.cpp` | `LoRaEncoder::work`, `encodeFec` | Pothos framework, `LoRaCodes.hpp` utilities | `std::vector` for data and symbols; output `Pothos::BufferChunk` | Pothos block wrapper; no Poco/JSON |
 | `LoRaDecoder.cpp` | `LoRaDecoder::work`, `drop` | Pothos framework, `LoRaCodes.hpp` | `std::vector` for buffers; output `Pothos::BufferChunk` | Pothos block wrapper; no Poco/JSON |
-| `ChirpGenerator.hpp` | `genChirp` | `<complex>`, `<cmath>` (includes `Pothos/Config.hpp` for macros) | Writes to caller-provided buffer; no dynamic allocation | Independent; remove Pothos include if unused |
+| `ChirpGenerator.hpp` | `genChirp` | `<complex>`, `<cmath>` (includes `Pothos/Config.hpp` for macros) | Writes to caller-provided buffer; no dynamic allocation | Supports bandwidth scaling via an extra parameter |
 | `LoRaDetector.hpp` | `feed`, `detect` | `kissfft.hh`, `<complex>` | Uses caller-provided FFT work buffers and plan | Independent; no external framework |
 | `LoRaCodes.hpp` | `sx1272DataChecksum`, `diagonalInterleaveSx`, `grayToBinary16`, `SX1232RadioComputeWhitening` | Standard library (`<cstdint>`) only | Operates on caller buffers; no dynamic allocation | Contains CRC, interleaving, Gray mapping, whitening |
 | `kissfft.hh` | `kissfft::transform` | `<complex>`, `<vector>` (optional `<alloca.h>`) | Twiddles and stage data allocated in constructor (init-only) | Standalone FFT backend |

--- a/README_LoRaSDR_porting.md
+++ b/README_LoRaSDR_porting.md
@@ -11,7 +11,7 @@
 ### In Scope (MVP)
 - **Modulation / Demodulation** pipeline: **dechirp → FFT → symbol decision**.
 - **Coding Layer**: data whitening, interleaving, Hamming (CR 4/5–4/8), Gray mapping, header/payload CRC, sync-word handling.
-- **Parameters**: SF7..SF12, BW = 125 kHz (initially), CR = 4/5..4/8, explicit header.
+ - **Parameters**: SF7..SF12, BW = 125/250/500 kHz, CR = 4/5..4/8, explicit header.
 
 ### Success Criteria
 - **One library target** with **KISS-FFT only** as dependency.

--- a/include/lora_phy/ChirpGenerator.hpp
+++ b/include/lora_phy/ChirpGenerator.hpp
@@ -22,11 +22,11 @@
  */
 template <typename Type>
 int genChirp(std::complex<Type> *samps, int N, int osr, int NN, Type f0, bool down,
-             const Type ampl, Type &phaseAccum)
+             const Type ampl, Type &phaseAccum, Type bw_scale = Type(1))
 {
-    const Type fMin = -M_PI / osr;
-    const Type fMax = M_PI / osr;
-    const Type fStep = (2 * M_PI) / (N * osr * osr);
+    const Type fMin = -M_PI * bw_scale / osr;
+    const Type fMax = M_PI * bw_scale / osr;
+    const Type fStep = (2 * M_PI * bw_scale) / (N * osr * osr);
     float f = fMin + f0;
     int i;
     if (down) {

--- a/include/lora_phy/phy.hpp
+++ b/include/lora_phy/phy.hpp
@@ -30,11 +30,28 @@ enum class window_type {
     window_hann,
 };
 
+/**
+ * Supported LoRa bandwidths in hertz.
+ */
+enum class bandwidth : unsigned {
+    bw_125 = 125000,
+    bw_250 = 250000,
+    bw_500 = 500000,
+};
+
+constexpr float bw_to_hz(bandwidth bw) {
+    return static_cast<float>(static_cast<unsigned>(bw));
+}
+
+constexpr float bw_scale(bandwidth bw) {
+    return bw_to_hz(bw) / 125000.0f;
+}
+
 struct lora_params {
-    unsigned sf{}; ///< Spreading factor
-    unsigned bw{}; ///< Bandwidth index
-    unsigned cr{}; ///< Coding rate index
-    unsigned osr{1}; ///< Oversampling ratio
+    unsigned sf{};                   ///< Spreading factor
+    bandwidth bw{bandwidth::bw_125}; ///< Operating bandwidth
+    unsigned cr{};                   ///< Coding rate index
+    unsigned osr{1};                 ///< Oversampling ratio
     window_type window{window_type::window_none}; ///< Optional analysis window
 };
 
@@ -68,6 +85,7 @@ struct lora_workspace {
 
     lora_metrics         metrics{};    ///< updated by processing functions
     unsigned             osr{1};       ///< oversampling ratio stored during init
+    bandwidth           bw{bandwidth::bw_125}; ///< bandwidth stored during init
 };
 
 // ---------------------------------------------------------------------------
@@ -167,7 +185,7 @@ void lora_demod_free(lora_demod_workspace* ws);
 // samples_per_symbol = 1 << sf
 size_t lora_modulate(const uint16_t* symbols, size_t symbol_count,
                      std::complex<float>* out_samples, unsigned sf, unsigned osr,
-                     float amplitude = 1.0f);
+                     bandwidth bw, float amplitude = 1.0f);
 
 // Demodulate complex samples into symbol indices using a prepared workspace.
 size_t lora_demodulate(lora_demod_workspace* ws,

--- a/runners/lora_phy_vector_dump.cpp
+++ b/runners/lora_phy_vector_dump.cpp
@@ -17,7 +17,7 @@ namespace {
 void usage(const char* prog) {
     std::cerr << "Usage: " << prog
               << " --out=DIR [--sf=N] [--bytes=N] [--seed=N] [--osr=N]"
-              << " [--dump=STAGE,...] [--window=hann]\n";
+              << " [--bw=HZ] [--dump=STAGE,...] [--window=hann]\n";
 }
 
 } // namespace
@@ -26,6 +26,7 @@ int main(int argc, char** argv) {
     unsigned sf = 7;
     unsigned seed = 1;
     unsigned osr = 1;
+    bandwidth bw = bandwidth::bw_125;
     size_t byte_count = 16;
     std::string out_dir;
     std::set<std::string> dumps;
@@ -41,6 +42,18 @@ int main(int argc, char** argv) {
             byte_count = static_cast<size_t>(std::stoul(arg.substr(8)));
         } else if (arg.rfind("--osr=", 0) == 0) {
             osr = static_cast<unsigned>(std::stoul(arg.substr(6)));
+        } else if (arg.rfind("--bw=", 0) == 0) {
+            unsigned val = static_cast<unsigned>(std::stoul(arg.substr(5)));
+            if (val == 125000)
+                bw = bandwidth::bw_125;
+            else if (val == 250000)
+                bw = bandwidth::bw_250;
+            else if (val == 500000)
+                bw = bandwidth::bw_500;
+            else {
+                std::cerr << "Unsupported bandwidth: " << val << "\n";
+                return 1;
+            }
         } else if (arg.rfind("--out=", 0) == 0) {
             out_dir = arg.substr(6);
         } else if (arg.rfind("--dump=", 0) == 0) {
@@ -107,7 +120,7 @@ int main(int argc, char** argv) {
     ws.window = window.data();
     lora_params params{};
     params.sf = sf;
-    params.bw = 0;
+    params.bw = bw;
     params.cr = 0;
     params.osr = osr;
     params.window = win;

--- a/runners/rx_runner.cpp
+++ b/runners/rx_runner.cpp
@@ -14,7 +14,7 @@ namespace {
 
 void usage(const char* prog) {
     std::cerr << "Usage: " << prog
-              << " [--in=FILE] [--sf=N] [--cr=N] [--report-offsets]\n";
+              << " [--in=FILE] [--sf=N] [--cr=N] [--bw=HZ] [--report-offsets]\n";
     std::cerr << "Input samples are float32 IQ pairs" << std::endl;
 }
 
@@ -34,6 +34,18 @@ int main(int argc, char** argv) {
             params.sf = static_cast<unsigned>(std::stoul(arg.substr(5)));
         } else if (arg.rfind("--cr=", 0) == 0) {
             params.cr = static_cast<unsigned>(std::stoul(arg.substr(5)));
+        } else if (arg.rfind("--bw=", 0) == 0) {
+            unsigned val = static_cast<unsigned>(std::stoul(arg.substr(5)));
+            if (val == 125000)
+                params.bw = bandwidth::bw_125;
+            else if (val == 250000)
+                params.bw = bandwidth::bw_250;
+            else if (val == 500000)
+                params.bw = bandwidth::bw_500;
+            else {
+                std::cerr << "Unsupported bandwidth\n";
+                return 1;
+            }
         } else if (arg == "--report-offsets") {
             report_offsets = true;
         } else if (arg == "--help" || arg == "-h") {

--- a/runners/tx_runner.cpp
+++ b/runners/tx_runner.cpp
@@ -13,7 +13,7 @@ namespace {
 
 void usage(const char* prog) {
     std::cerr << "Usage: " << prog
-              << " --payload=HEX [--sf=N] [--cr=N] [--out=FILE|--stdout]\n";
+              << " --payload=HEX [--sf=N] [--cr=N] [--bw=HZ] [--out=FILE|--stdout]\n";
 }
 
 bool parse_hex_payload(const std::string& hex, std::vector<uint8_t>& out) {
@@ -44,6 +44,18 @@ int main(int argc, char** argv) {
             params.sf = static_cast<unsigned>(std::stoul(arg.substr(5)));
         } else if (arg.rfind("--cr=", 0) == 0) {
             params.cr = static_cast<unsigned>(std::stoul(arg.substr(5)));
+        } else if (arg.rfind("--bw=", 0) == 0) {
+            unsigned val = static_cast<unsigned>(std::stoul(arg.substr(5)));
+            if (val == 125000)
+                params.bw = bandwidth::bw_125;
+            else if (val == 250000)
+                params.bw = bandwidth::bw_250;
+            else if (val == 500000)
+                params.bw = bandwidth::bw_500;
+            else {
+                std::cerr << "Unsupported bandwidth\n";
+                return 1;
+            }
         } else if (arg.rfind("--out=", 0) == 0) {
             out_path = arg.substr(6);
         } else if (arg == "--stdout") {

--- a/scripts/generate_lora_phy_vectors.py
+++ b/scripts/generate_lora_phy_vectors.py
@@ -49,6 +49,7 @@ class Manifest:
     seed: int
     bytes: int
     osr: int
+    bw: int
     files: List[FileRecord]
 
 
@@ -58,6 +59,7 @@ def main() -> None:
     parser.add_argument("--seed", type=int, default=0, help="Random seed")
     parser.add_argument("--bytes", type=int, default=16, help="Number of payload bytes")
     parser.add_argument("--osr", type=int, default=1, help="Oversampling ratio")
+    parser.add_argument("--bw", type=int, default=125000, help="LoRa bandwidth in Hz")
     parser.add_argument(
         "--out",
         required=True,
@@ -93,6 +95,7 @@ def main() -> None:
         f"--bytes={args.bytes}",
         f"--out={out_dir}",
         f"--osr={args.osr}",
+        f"--bw={args.bw}",
     ]
     if args.window != "none":
         cmd.append(f"--window={args.window}")
@@ -129,7 +132,7 @@ def main() -> None:
             continue
         files.append(FileRecord(path.name, compute_checksum(path)))
 
-    manifest = Manifest(args.sf, args.seed, args.bytes, args.osr, files)
+    manifest = Manifest(args.sf, args.seed, args.bytes, args.osr, args.bw, files)
     with (out_dir / "manifest.json").open("w") as handle:
         json.dump(asdict(manifest), handle, indent=2)
 

--- a/scripts/generate_vectors.sh
+++ b/scripts/generate_vectors.sh
@@ -10,16 +10,19 @@ SUBDIR=${1:-sf7}
 # Oversampling ratio
 OSR=${2:-1}
 
-# Generate vectors via the standalone library without windowing
-python3 "$SCRIPT_DIR/generate_lora_phy_vectors.py" \
-    --sf=7 --seed=1 --bytes=16 --osr="$OSR" --out="${SUBDIR}_nowin"
+# Generate vectors for supported bandwidths via the standalone library
+for BW in 125000 250000 500000; do
+    python3 "$SCRIPT_DIR/generate_lora_phy_vectors.py" \
+        --sf=7 --seed=1 --bytes=16 --osr="$OSR" --bw="$BW" \
+        --out="${SUBDIR}_bw$((BW/1000))_nowin"
 
-# Generate vectors with a Hann window for comparison
-python3 "$SCRIPT_DIR/generate_lora_phy_vectors.py" \
-    --sf=7 --seed=1 --bytes=16 --osr="$OSR" --window=hann --out="${SUBDIR}_hann"
+    python3 "$SCRIPT_DIR/generate_lora_phy_vectors.py" \
+        --sf=7 --seed=1 --bytes=16 --osr="$OSR" --bw="$BW" \
+        --window=hann --out="${SUBDIR}_bw$((BW/1000))_hann"
+done
 
-# Generate matching vectors via the original LoRa-SDR
+# Generate matching vectors via the original LoRa-SDR (125 kHz only)
 python3 "$SCRIPT_DIR/generate_baseline_vectors.py" \
     --sf=7 --cr=4/5 --snr=30 --seed=1 --out="$SUBDIR"
 
-echo "Vectors generated under vectors/lora_phy/${SUBDIR}_nowin, vectors/lora_phy/${SUBDIR}_hann and vectors/lorasdr/$SUBDIR"
+echo "Vectors generated under vectors/lora_phy/${SUBDIR}_bw125_nowin, vectors/lora_phy/${SUBDIR}_bw250_nowin, vectors/lora_phy/${SUBDIR}_bw500_nowin and vectors/lorasdr/$SUBDIR"

--- a/src/phy/LoRaMod.cpp
+++ b/src/phy/LoRaMod.cpp
@@ -6,17 +6,18 @@ namespace lora_phy {
 
 size_t lora_modulate(const uint16_t* symbols, size_t symbol_count,
                      std::complex<float>* out_samples, unsigned sf, unsigned osr,
-                     float amplitude)
+                     bandwidth bw, float amplitude)
 {
     const size_t N = size_t(1) << sf; // base samples per symbol
     const size_t step = N * osr;
     float phase = 0.0f;
+    const float bw_scale = lora_phy::bw_scale(bw);
     for (size_t s = 0; s < symbol_count; ++s)
     {
-        const float freq = (2.0f * float(M_PI) * symbols[s]) /
+        const float freq = (2.0f * float(M_PI) * symbols[s] * bw_scale) /
                            (float(N) * static_cast<float>(osr));
         genChirp(out_samples + s * step, static_cast<int>(N), static_cast<int>(osr),
-                 static_cast<int>(step), freq, false, amplitude, phase);
+                 static_cast<int>(step), freq, false, amplitude, phase, bw_scale);
     }
     return symbol_count * step;
 }

--- a/tests/e2e_chain_test.cpp
+++ b/tests/e2e_chain_test.cpp
@@ -73,14 +73,17 @@ int main() {
         const size_t samples_per_symbol = 1u << p.sf;
         const size_t sample_count = symbol_count * samples_per_symbol;
         std::vector<std::complex<float>> samples(sample_count);
-        lora_phy::lora_modulate(symbols.data(), symbol_count, samples.data(), p.sf, 1);
+        lora_phy::lora_modulate(symbols.data(), symbol_count, samples.data(), p.sf, 1,
+                                static_cast<lora_phy::bandwidth>(p.bw));
 
         // dechirp the samples before demodulation
         std::vector<std::complex<float>> dechirped(sample_count);
         std::vector<std::complex<float>> down(samples_per_symbol);
         float phase = 0.0f;
+        float scale = lora_phy::bw_scale(static_cast<lora_phy::bandwidth>(p.bw));
         genChirp(down.data(), static_cast<int>(samples_per_symbol), 1,
-                 static_cast<int>(samples_per_symbol), 0.0f, true, 1.0f, phase);
+                 static_cast<int>(samples_per_symbol), 0.0f, true, 1.0f, phase,
+                 scale);
         for (size_t s = 0; s < symbol_count; ++s) {
             for (size_t i = 0; i < samples_per_symbol; ++i) {
                 dechirped[s * samples_per_symbol + i] =

--- a/tests/no_alloc_test.cpp
+++ b/tests/no_alloc_test.cpp
@@ -16,7 +16,8 @@ int main() {
 
     {
         alloc_tracker::Guard guard;
-        lora_phy::lora_modulate(symbols.data(), symbol_count, samples.data(), sf, 1);
+        lora_phy::lora_modulate(symbols.data(), symbol_count, samples.data(), sf, 1,
+                                lora_phy::bandwidth::bw_125);
         if (guard.count() != 0) {
             std::cerr << "Allocation occurred in modulate" << std::endl;
             return 1;

--- a/tests/performance_test.cpp
+++ b/tests/performance_test.cpp
@@ -86,8 +86,10 @@ int main() {
         // precompute downchirp for dechirp
         std::vector<std::complex<float>> down(samples_per_symbol);
         float phase = 0.0f;
+        float scale = lora_phy::bw_scale(static_cast<lora_phy::bandwidth>(p.bw));
         genChirp(down.data(), static_cast<int>(samples_per_symbol), 1,
-                 static_cast<int>(samples_per_symbol), 0.0f, true, 1.0f, phase);
+                 static_cast<int>(samples_per_symbol), 0.0f, true, 1.0f, phase,
+                 scale);
 
         lora_phy::lora_demod_workspace ws{};
         lora_phy::lora_demod_init(&ws, p.sf);
@@ -96,7 +98,9 @@ int main() {
         unsigned long long c_start = __rdtsc();
 
         for (size_t pkt = 0; pkt < PACKETS; ++pkt) {
-            lora_phy::lora_modulate(symbols.data(), symbol_count, samples.data(), p.sf, 1);
+            lora_phy::lora_modulate(symbols.data(), symbol_count, samples.data(),
+                                    p.sf, 1,
+                                    static_cast<lora_phy::bandwidth>(p.bw));
             for (size_t s = 0; s < symbol_count; ++s) {
                 for (size_t i = 0; i < samples_per_symbol; ++i) {
                     dechirped[s * samples_per_symbol + i] =


### PR DESCRIPTION
## Summary
- Add `bandwidth` enum to `lora_params` and workspace to cover 125/250/500 kHz
- Scale chirp generation, modulation and demodulation by selected bandwidth
- Extend vector-generation scripts and runners with bandwidth option

## Testing
- `cmake --build .`
- `ctest` *(fails: Failed to load IQ samples for profile sf7_bw125_cr45; mismatch for sf9_bw250_cr48 and sf12_bw500_cr45)*

------
https://chatgpt.com/codex/tasks/task_e_68bd050483a48329b95137386eabe6fe