### PR TITLE
Add minimal LoRaWAN frame helpers

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -91,6 +91,35 @@ Returns a pointer to the metrics collected during the most recent processing
 call (`decode` or `demodulate`).  The caller must not free the returned pointer
 and it remains valid until the next call that updates the metrics.
 
+## LoRaWAN helpers
+
+An optional helper module in `include/lorawan/lorawan.hpp` provides small
+structures representing LoRaWAN headers along with utilities to build and
+parse frames.
+
+### Data structures
+
+* `lorawan::MHDR` – message header carrying the frame type and protocol major
+  version.
+* `lorawan::FHDR` – frame header containing device address, frame control,
+  frame counter and optional MAC commands (`fopts`).
+* `lorawan::Frame` – aggregates `MHDR`, `FHDR` and the FRMPayload bytes.
+
+### `ssize_t lorawan::build_frame(lora_phy::lora_workspace *ws,
+                                  const lorawan::Frame &frame,
+                                  uint16_t *symbols,
+                                  size_t symbol_cap);`
+Serialises `frame`, appends a CRC32-based MIC and encodes the resulting buffer
+into LoRa symbols using `lora_phy::encode`.  Returns the number of symbols
+written or a negative value on error.
+
+### `ssize_t lorawan::parse_frame(lora_phy::lora_workspace *ws,
+                                  const uint16_t *symbols, size_t count,
+                                  lorawan::Frame &out);`
+Decodes symbols with `lora_phy::decode`, verifies the MIC and populates `out`
+with the parsed fields.  The return value is the number of payload bytes or a
+negative error code.
+
 ## Buffer Ownership and Error Handling
 
 All input and output buffers are owned by the caller.  The library reads from or

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,13 +10,17 @@ option(BUILD_TESTS "Build tests" ON)
 option(BUILD_RUNNERS "Build runners" ON)
 
 file(GLOB LORA_PHY_SOURCES CONFIGURE_DEPENDS src/phy/*.cpp)
+file(GLOB LORAWAN_SOURCES CONFIGURE_DEPENDS src/lorawan/*.cpp)
+list(APPEND LORA_PHY_SOURCES ${LORAWAN_SOURCES})
 
 add_library(lora_phy STATIC ${LORA_PHY_SOURCES})
 
 target_include_directories(lora_phy PUBLIC include)
 
 # ensure headers like kissfft.hh are part of the target for IDEs
-target_sources(lora_phy PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include/lora_phy/kissfft.hh)
+target_sources(lora_phy PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/lora_phy/kissfft.hh
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/lorawan/lorawan.hpp)
 
 if(BUILD_RUNNERS)
     add_executable(lora_phy_vector_dump runners/lora_phy_vector_dump.cpp)
@@ -29,6 +33,10 @@ if(BUILD_RUNNERS)
     # Receive runner converting IQ samples back into payload bytes
     add_executable(rx_runner runners/rx_runner.cpp)
     target_link_libraries(rx_runner PRIVATE lora_phy)
+
+    # Simple round-trip test for LoRaWAN frame helpers
+    add_executable(lorawan_roundtrip runners/lorawan_roundtrip.cpp)
+    target_link_libraries(lorawan_roundtrip PRIVATE lora_phy)
 endif()
 
 if(BUILD_TESTS)

--- a/README_LoRaSDR_porting.md
+++ b/README_LoRaSDR_porting.md
@@ -171,7 +171,8 @@ regenerate vectors if any convention is adjusted.
   regenerate vectors with `scripts/generate_vectors.sh` to compare windowed and
   unwindowed behaviour.
 - **Additional BW**: 250/500 kHz support.
-- **LoRaWAN**: use the PHY as a base for LoRaWAN frame building/parsing later on.
+- **LoRaWAN**: use the PHY as a base for LoRaWAN frame building/parsing later on. See
+  the “LoRaWAN helpers” section in `API_SPEC.md` for the emerging interface.
 
 ---
 

--- a/include/lorawan/lorawan.hpp
+++ b/include/lorawan/lorawan.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include <lora_phy/phy.hpp>
+
+namespace lorawan {
+
+// Basic LoRaWAN message types
+enum class MType : uint8_t {
+    JoinRequest = 0,
+    JoinAccept = 1,
+    UnconfirmedDataUp = 2,
+    UnconfirmedDataDown = 3,
+    ConfirmedDataUp = 4,
+    ConfirmedDataDown = 5,
+    RFU = 6,
+    Proprietary = 7,
+};
+
+struct MHDR {
+    MType   mtype{MType::UnconfirmedDataUp};
+    uint8_t major{0};
+};
+
+struct MACCommand {
+    uint8_t cid{};
+    std::vector<uint8_t> payload;
+};
+
+struct FHDR {
+    uint32_t devaddr{};
+    uint8_t  fctrl{}; // lower 4 bits encode FOpts length
+    uint16_t fcnt{};
+    std::vector<uint8_t> fopts; // raw bytes of MAC commands
+};
+
+struct Frame {
+    MHDR mhdr;
+    FHDR fhdr;
+    std::vector<uint8_t> payload; // FRMPayload bytes
+};
+
+// Compute MIC over @p data using CRC32
+uint32_t compute_mic(const uint8_t* data, size_t len);
+
+// Build @p frame into LoRa symbols using lora_phy::encode()
+ssize_t build_frame(lora_phy::lora_workspace* ws,
+                    const Frame& frame,
+                    uint16_t* symbols,
+                    size_t symbol_cap);
+
+// Parse symbols back into a Frame verifying the MIC
+ssize_t parse_frame(lora_phy::lora_workspace* ws,
+                    const uint16_t* symbols,
+                    size_t symbol_count,
+                    Frame& out);
+
+} // namespace lorawan
+

--- a/runners/lorawan_roundtrip.cpp
+++ b/runners/lorawan_roundtrip.cpp
@@ -1,0 +1,71 @@
+#include <lorawan/lorawan.hpp>
+#include <lora_phy/phy.hpp>
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+static bool hex_to_bytes(const std::string& hex, std::vector<uint8_t>& out) {
+    if (hex.size() % 2) return false;
+    out.clear();
+    for (size_t i = 0; i < hex.size(); i += 2) {
+        uint8_t b = static_cast<uint8_t>(std::stoul(hex.substr(i, 2), nullptr, 16));
+        out.push_back(b);
+    }
+    return true;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <hex_payload>\n";
+        return 1;
+    }
+    std::vector<uint8_t> payload;
+    if (!hex_to_bytes(argv[1], payload)) {
+        std::cerr << "Invalid hex input\n";
+        return 1;
+    }
+
+    lorawan::MHDR mhdr;
+    mhdr.mtype = lorawan::MType::UnconfirmedDataUp;
+    mhdr.major = 0;
+
+    lorawan::FHDR fhdr;
+    fhdr.devaddr = 0x01020304u;
+    fhdr.fctrl = 0x00u;
+    fhdr.fcnt = 1u;
+
+    lorawan::Frame frame;
+    frame.mhdr = mhdr;
+    frame.fhdr = fhdr;
+    frame.payload = payload;
+
+    lora_phy::lora_workspace ws{};
+    lora_phy::lora_params params{};
+    params.sf = 7;
+    params.cr = 1;
+    params.bw = lora_phy::bandwidth::bw_125;
+    lora_phy::init(&ws, &params);
+
+    std::vector<uint16_t> symbols(payload.size() * 2 + 32);
+    ssize_t sc = lorawan::build_frame(&ws, frame, symbols.data(), symbols.size());
+    if (sc < 0) {
+        std::cerr << "build_frame failed\n";
+        return 2;
+    }
+
+    lorawan::Frame parsed;
+    ssize_t pc = lorawan::parse_frame(&ws, symbols.data(), static_cast<size_t>(sc), parsed);
+    if (pc < 0) {
+        std::cerr << "parse_frame failed\n";
+        return 3;
+    }
+
+    if (parsed.payload != payload) {
+        std::cerr << "Round-trip mismatch\n";
+        return 4;
+    }
+
+    std::cout << "roundtrip ok" << std::endl;
+    return 0;
+}

--- a/src/lorawan/lorawan.cpp
+++ b/src/lorawan/lorawan.cpp
@@ -1,0 +1,93 @@
+#include <lorawan/lorawan.hpp>
+
+#include <algorithm>
+#include <vector>
+
+namespace lorawan {
+
+namespace {
+// Simple CRC32 implementation for MIC generation
+static uint32_t crc32(const uint8_t* data, size_t len) {
+    uint32_t crc = 0xFFFFFFFFu;
+    for (size_t i = 0; i < len; ++i) {
+        crc ^= data[i];
+        for (int j = 0; j < 8; ++j) {
+            if (crc & 1)
+                crc = (crc >> 1) ^ 0xEDB88320u;
+            else
+                crc >>= 1;
+        }
+    }
+    return ~crc;
+}
+} // namespace
+
+uint32_t compute_mic(const uint8_t* data, size_t len) {
+    return crc32(data, len);
+}
+
+ssize_t build_frame(lora_phy::lora_workspace* ws,
+                    const Frame& frame,
+                    uint16_t* symbols,
+                    size_t symbol_cap) {
+    if (!ws || !symbols) return -1;
+    std::vector<uint8_t> bytes;
+    bytes.reserve(16 + frame.payload.size());
+    uint8_t mhdr = (static_cast<uint8_t>(frame.mhdr.mtype) << 5) |
+                   (frame.mhdr.major & 0x3);
+    bytes.push_back(mhdr);
+    uint32_t a = frame.fhdr.devaddr;
+    bytes.push_back(static_cast<uint8_t>(a & 0xFF));
+    bytes.push_back(static_cast<uint8_t>((a >> 8) & 0xFF));
+    bytes.push_back(static_cast<uint8_t>((a >> 16) & 0xFF));
+    bytes.push_back(static_cast<uint8_t>((a >> 24) & 0xFF));
+    uint8_t fctrl = (frame.fhdr.fctrl & 0xF0) |
+                    (static_cast<uint8_t>(frame.fhdr.fopts.size()) & 0x0F);
+    bytes.push_back(fctrl);
+    bytes.push_back(static_cast<uint8_t>(frame.fhdr.fcnt & 0xFF));
+    bytes.push_back(static_cast<uint8_t>((frame.fhdr.fcnt >> 8) & 0xFF));
+    bytes.insert(bytes.end(), frame.fhdr.fopts.begin(), frame.fhdr.fopts.end());
+    bytes.insert(bytes.end(), frame.payload.begin(), frame.payload.end());
+    uint32_t mic = compute_mic(bytes.data(), bytes.size());
+    bytes.push_back(static_cast<uint8_t>(mic & 0xFF));
+    bytes.push_back(static_cast<uint8_t>((mic >> 8) & 0xFF));
+    bytes.push_back(static_cast<uint8_t>((mic >> 16) & 0xFF));
+    bytes.push_back(static_cast<uint8_t>((mic >> 24) & 0xFF));
+    return lora_phy::encode(ws, bytes.data(), bytes.size(), symbols, symbol_cap);
+}
+
+ssize_t parse_frame(lora_phy::lora_workspace* ws,
+                    const uint16_t* symbols,
+                    size_t symbol_count,
+                    Frame& out) {
+    if (!ws || !symbols) return -1;
+    std::vector<uint8_t> bytes(symbol_count / 2 + 8);
+    ssize_t produced = lora_phy::decode(ws, symbols, symbol_count,
+                                        bytes.data(), bytes.size());
+    if (produced < 0) return produced;
+    if (static_cast<size_t>(produced) < 1 + 4 + 1 + 2 + 4) return -1;
+    size_t len = static_cast<size_t>(produced);
+    uint32_t mic = bytes[len - 4] | (bytes[len - 3] << 8) |
+                   (bytes[len - 2] << 16) | (bytes[len - 1] << 24);
+    uint32_t calc = compute_mic(bytes.data(), len - 4);
+    if (mic != calc) return -2;
+    size_t idx = 0;
+    uint8_t mhdr = bytes[idx++];
+    out.mhdr.mtype = static_cast<MType>(mhdr >> 5);
+    out.mhdr.major = mhdr & 0x3;
+    out.fhdr.devaddr = bytes[idx] | (bytes[idx + 1] << 8) |
+                       (bytes[idx + 2] << 16) | (bytes[idx + 3] << 24);
+    idx += 4;
+    out.fhdr.fctrl = bytes[idx++];
+    unsigned fopts_len = out.fhdr.fctrl & 0x0F;
+    out.fhdr.fcnt = bytes[idx] | (bytes[idx + 1] << 8);
+    idx += 2;
+    if (idx + fopts_len > len - 4) return -1;
+    out.fhdr.fopts.assign(bytes.begin() + idx, bytes.begin() + idx + fopts_len);
+    idx += fopts_len;
+    out.payload.assign(bytes.begin() + idx, bytes.begin() + (len - 4));
+    return static_cast<ssize_t>(out.payload.size());
+}
+
+} // namespace lorawan
+

--- a/tests/lorawan_roundtrip.py
+++ b/tests/lorawan_roundtrip.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import os
+import binascii
+import subprocess
+from pathlib import Path
+import secrets
+
+def run_roundtrip(exe: Path, payload: bytes) -> bool:
+    hex_payload = binascii.hexlify(payload).decode()
+    result = subprocess.run([str(exe), hex_payload], capture_output=True, text=True)
+    return result.returncode == 0
+
+def main():
+    root = Path(__file__).resolve().parent.parent
+    exe = root / 'build' / 'lorawan_roundtrip'
+    if not exe.exists():
+        raise SystemExit(f"runner not found: {exe}")
+    for _ in range(5):
+        payload = secrets.token_bytes(8)
+        if not run_roundtrip(exe, payload):
+            raise SystemExit('roundtrip failed')
+    print('LoRaWAN round-trip tests passed')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- introduce `lorawan` module with MHDR/FHDR/MAC command structures and MIC
- provide helpers to build and parse LoRaWAN frames on top of `lora_phy`
- add a small round-trip runner and python script integration test
- document LoRaWAN helper API and reference it in porting notes

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest` *(fails: mismatch in legacy vector tests)*
- `python tests/lorawan_roundtrip.py`

------
https://chatgpt.com/codex/tasks/task_e_68bd083a1d888329a2b31de7697933dc