### PR TITLE
Document KISS FFT licensing and add upstream references

### DIFF
--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -1,0 +1,38 @@
+# Third-Party Licenses
+
+## KISS FFT
+
+Portions of this project are derived from the [KISS FFT](https://github.com/mborgerding/kissfft) library.
+
+KISS FFT license (BSD-3-Clause):
+
+Copyright (c) 2003-2010 Mark Borgerding. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+The primary project code is licensed under the Boost Software License 1.0
+(as indicated by SPDX identifiers in source files). This permissive license
+is compatible with the BSD-3-Clause license used by KISS FFT, allowing the
+inclusion and redistribution of BSD-licensed components within this project.

--- a/include/lora_phy/kissfft.hh
+++ b/include/lora_phy/kissfft.hh
@@ -1,3 +1,5 @@
+// Derived from the KISS FFT library; see THIRD_PARTY.md for the BSD-3-Clause license details.
+// SPDX-License-Identifier: BSD-3-Clause
 #ifndef KISSFFT_CLASS_HH
 #define KISSFFT_CLASS_HH
 #include <complex>

--- a/legacy/kissfft.hh
+++ b/legacy/kissfft.hh
@@ -1,3 +1,5 @@
+// Derived from the KISS FFT library; see THIRD_PARTY.md for the BSD-3-Clause license details.
+// SPDX-License-Identifier: BSD-3-Clause
 #ifndef KISSFFT_CLASS_HH
 #define KISSFFT_CLASS_HH
 #include <complex>


### PR DESCRIPTION
## Summary
- Record KISS FFT's BSD-3-Clause license and Boost compatibility in `THIRD_PARTY.md`
- Reference the KISS FFT license in `kissfft.hh` headers

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `./build/lora_phy_tests` *(fails: missing vector directories)*

------
https://chatgpt.com/codex/tasks/task_e_68bd17a280048329b48206b9e5025dc8