### PR TITLE
Remove submodule and encode baseline vectors

### DIFF
--- a/legacy_vectors/lorasdr_baseline/.gitignore
+++ b/legacy_vectors/lorasdr_baseline/.gitignore
@@ -1,3 +1,4 @@
 # Ignore generated baseline vectors and manifests
 *
 !.gitignore
+!*.b64

--- a/legacy_vectors/lorasdr_baseline/placeholder.txt.b64
+++ b/legacy_vectors/lorasdr_baseline/placeholder.txt.b64
@@ -1,0 +1,1 @@
+cGxhY2Vob2xkZXI=

--- a/scripts/generate_baseline_vectors.py
+++ b/scripts/generate_baseline_vectors.py
@@ -10,6 +10,7 @@ with SHA256 checksums is written so downstream tests can verify the data.
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import json
 import os
@@ -65,10 +66,13 @@ def main() -> None:
     parser.add_argument("--seed", type=int, default=0, help="Random seed")
     parser.add_argument(
         "--binary",
-        default=os.environ.get("LORASDR_AWGN_BIN", "external/lorasdr_orig/build/lora_awgn_sim"),
+        default=os.environ.get("LORASDR_AWGN_BIN"),
         help="Path to the lora_awgn_sim binary",
     )
     args = parser.parse_args()
+
+    if args.binary is None:
+        parser.error("AWGN simulation binary not specified (use --binary or set LORASDR_AWGN_BIN)")
 
     awgn_bin = pathlib.Path(args.binary).resolve()
     if not awgn_bin.is_file():
@@ -92,7 +96,11 @@ def main() -> None:
     for path in sorted(out_dir.glob("*")):
         if path.name == "manifest.json":
             continue
-        files.append(FileRecord(path.name, compute_checksum(path)))
+        b64_path = path.with_suffix(path.suffix + ".b64")
+        with path.open("rb") as src, b64_path.open("wb") as dst:
+            base64.encode(src, dst)
+        path.unlink()
+        files.append(FileRecord(b64_path.name, compute_checksum(b64_path)))
 
     manifest = Manifest(args.sf, args.cr, args.snr, args.seed, files)
     with (out_dir / "manifest.json").open("w") as handle:


### PR DESCRIPTION
## Summary
- drop upstream `external/lorasdr_orig` submodule and its config
- add placeholder base64 baseline file and allow tracking of `.b64` vectors
- update baseline generation script to require explicit AWGN binary and emit base64 data

## Testing
- `python -m py_compile scripts/generate_baseline_vectors.py`
- `cmake -B build -S .`
- `cmake --build build`
- `./build/lora_phy_tests` *(fails: Failed to load IQ samples for profile sf7_bw125_cr45; Mismatch in profile sf9_bw250_cr48; Mismatch in profile sf12_bw500_cr45)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1ccc6e088329b2bd3405b5b38efb