### PR TITLE
Clarify bit ordering and add roundtrip test

### DIFF
--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -4,6 +4,7 @@ int bit_exact_test_main();
 int e2e_chain_test_main();
 int no_alloc_test_main();
 int performance_test_main();
+int roundtrip_test_main();
 
 int main() {
     int result = 0;
@@ -11,6 +12,7 @@ int main() {
     result |= e2e_chain_test_main();
     result |= no_alloc_test_main();
     result |= performance_test_main();
+    result |= roundtrip_test_main();
     if (result != 0) {
         std::printf("Some tests failed\n");
     }


### PR DESCRIPTION
## Summary
- document LSB-first bit numbering for Gray code helpers and diagonal interleaver
- refactor interleaver/deinterleaver loops to show explicit bit positions
- add base64-backed payload↔symbol roundtrip unit test

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build` *(fails: Failed to load IQ samples for profile sf7_bw125_cr45)*

------
https://chatgpt.com/codex/tasks/task_e_68bd30ce7cdc8329bbc7ef22d4363f67