### PR TITLE
docs: add test plan and update references

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -1,4 +1,8 @@
 # API Specification
+*Version:* 1.0  
+*Date:* 2025-02-14
+
+See also: [Porting Notes](PORTING_NOTES.md), [Third-Party Components](THIRD_PARTY.md), [Test Plan](TEST_PLAN.md)
 
 ## Workspace
 

--- a/PORTING_NOTES.md
+++ b/PORTING_NOTES.md
@@ -1,4 +1,8 @@
 # Porting Notes
+*Version:* 1.0  
+*Date:* 2025-02-14
+
+See also: [API Specification](API_SPEC.md), [Third-Party Components](THIRD_PARTY.md), [Test Plan](TEST_PLAN.md)
 
 This document summarizes core functions, dependencies, and allocation models for selected modules in the LoRa SDR lightweight library.
 

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -1,0 +1,56 @@
+# Test Plan
+*Version:* 1.0  
+*Date:* 2025-02-14
+
+See also: [API Specification](API_SPEC.md), [Porting Notes](PORTING_NOTES.md), [Third-Party Components](THIRD_PARTY.md)
+
+## Overview
+This document outlines how the library is validated. Detailed build and execution
+steps are provided in [README_TESTING.md](README_TESTING.md).
+
+## Bit-Exact Regression Tests
+Verifies modulation and demodulation against deterministic reference vectors.
+
+1. Generate vectors (once per update):
+   ```bash
+   scripts/generate_vectors.sh vectors/my_run
+   ```
+2. Build and run the regression:
+   ```bash
+   cmake -B build -S .
+   cmake --build build
+   ./build/bit_exact_test
+   ```
+
+The test reports `passed` for profiles that match the golden vectors listed in
+`tests/profiles.yaml`.
+
+## BER/PER Sweeps
+Evaluates bit and packet error rates over an AWGN channel for the profile matrix.
+
+```bash
+python tests/awgn_sweep.py --packets 100 --snr-start 0 --snr-stop 12 --snr-step 0.5 --out logs/awgn_sweep
+```
+
+The script writes `awgn_sweep.csv` and PNG plots under the chosen output
+directory.
+
+## Zero-Allocation Checks
+Ensures that runtime modulation and demodulation perform no dynamic memory
+allocation.
+
+```bash
+./build/no_alloc_test
+```
+
+Passing runs print `No allocations detected`.
+
+## Performance Measurements
+Captures throughput and cycle counts per symbol for each profile.
+
+```bash
+./build/performance_test
+```
+
+Results are stored in `logs/performance.csv` for further analysis.
+

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -1,4 +1,8 @@
 # Third-Party Components
+*Version:* 1.0  
+*Date:* 2025-02-14
+
+See also: [API Specification](API_SPEC.md), [Porting Notes](PORTING_NOTES.md), [Test Plan](TEST_PLAN.md)
 
 This project incorporates external code and artifacts. The sections below credit their sources, summarize any local modifications, and provide reproduction instructions for generated vectors where applicable.
 


### PR DESCRIPTION
## Summary
- add comprehensive `TEST_PLAN.md` covering bit-exact, BER/PER, zero-alloc, and performance tests
- add version/date headers and cross-links across API, porting, and third-party docs
- align docs with current code and dependencies

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `./build/lora_phy_tests` *(fails: missing reference vectors, manual interrupt)*
- `python tests/awgn_sweep.py --packets 1 --snr-start 0 --snr-stop 0 --snr-step 1 --out logs/awgn_sweep_test`


------
https://chatgpt.com/codex/tasks/task_e_68bd77638cec8329a7137c5920c310b7