### PR TITLE
Document base64 vector generation

### DIFF
--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -20,15 +20,16 @@ scripts/generate_vectors.sh vectors/my_run
 
 The script invokes `lora_phy_vector_dump` with typical parameters (SF7,
 16 payload bytes, seed 1) and writes the selected internal states to the
-provided directory.  Generated files include:
+provided directory as base64-encoded `.b64` files. Raw binaries are
+removed after encoding. Generated files include:
 
-* `payload.bin` – raw payload bytes
-* `pre_interleave.csv` – Hamming encoded codewords (decimal per line)
-* `post_interleave.csv` – symbols after the diagonal interleaver
-* `iq_samples.csv` – complex samples as `real,imag`
-* `demod_symbols.csv` – demodulated symbols
-* `deinterleave.csv` – codewords after deinterleaving
-* `decoded.bin` – final decoded payload
+* `payload.bin.b64` – base64-encoded payload bytes
+* `pre_interleave.csv.b64` – base64-encoded Hamming encoded codewords (decimal per line)
+* `post_interleave.csv.b64` – base64-encoded symbols after the diagonal interleaver
+* `iq_samples.csv.b64` – base64-encoded complex samples as `real,imag`
+* `demod_symbols.csv.b64` – base64-encoded demodulated symbols
+* `deinterleave.csv.b64` – base64-encoded codewords after deinterleaving
+* `decoded.bin.b64` – base64-encoded final decoded payload
 
 ## Running Tests
 Build the test executables:

--- a/scripts/generate_lora_phy_vectors.py
+++ b/scripts/generate_lora_phy_vectors.py
@@ -9,6 +9,7 @@ with SHA256 checksums is written so downstream tests can verify the data.
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import json
 import os
@@ -130,7 +131,11 @@ def main() -> None:
     for path in sorted(out_dir.glob("*")):
         if path.name == "manifest.json":
             continue
-        files.append(FileRecord(path.name, compute_checksum(path)))
+        b64_path = path.with_suffix(path.suffix + ".b64")
+        with path.open("rb") as src, b64_path.open("wb") as dst:
+            base64.encode(src, dst)
+        path.unlink()
+        files.append(FileRecord(b64_path.name, compute_checksum(b64_path)))
 
     manifest = Manifest(args.sf, args.seed, args.bytes, args.osr, args.bw, files)
     with (out_dir / "manifest.json").open("w") as handle:

--- a/vectors/README.md
+++ b/vectors/README.md
@@ -10,6 +10,12 @@ The script produces two subdirectories:
   implementation.
 * `lora_phy/` – vectors produced by this standalone library.
 
-Each run writes the raw data files alongside a `manifest.json` file with
-SHA256 checksums so changes can be detected without storing the binary
-files in the repository.
+Each run writes the base64-encoded `.b64` files alongside a `manifest.json`
+file with SHA256 checksums so changes can be detected without storing the
+binary files in the repository. The generation scripts output the data in
+base64 and delete the raw binary files once encoded. To recover a binary
+vector:
+
+```bash
+base64 --decode vectors/lorasdr/example.bin.b64 > example.bin
+```


### PR DESCRIPTION
## Summary
- document that generated vectors are stored as base64 `.b64` files
- encode `lora_phy` vectors to base64 and delete original binaries
- describe base64 vector outputs in test documentation

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `./build/lora_phy_tests` *(fails: missing IQ samples and vector directories)*

------
https://chatgpt.com/codex/tasks/task_e_68be80ca88e88329aac979bc3a7404ff