### PR TITLE
Fix allocation tracker to avoid mismatched delete

### DIFF
--- a/tests/alloc_tracker.h
+++ b/tests/alloc_tracker.h
@@ -29,20 +29,13 @@ struct Guard {
 
 inline void* operator new(std::size_t size) {
     alloc_tracker::counter().fetch_add(1, std::memory_order_relaxed);
-    if (void* p = std::malloc(size)) return p;
+    if (void* p = ::operator new(size, std::nothrow)) return p;
     throw std::bad_alloc();
-}
-
-inline void operator delete(void* ptr) noexcept {
-    std::free(ptr);
 }
 
 inline void* operator new[](std::size_t size) {
     alloc_tracker::counter().fetch_add(1, std::memory_order_relaxed);
-    if (void* p = std::malloc(size)) return p;
+    if (void* p = ::operator new[](size, std::nothrow)) return p;
     throw std::bad_alloc();
 }
 
-inline void operator delete[](void* ptr) noexcept {
-    std::free(ptr);
-}


### PR DESCRIPTION
## Summary
- use nothrow versions of operator new and new[] in allocation tracker
- drop custom delete operators so valgrind sees matching deallocations

## Testing
- `valgrind ./build/lora_phy_tests`


------
https://chatgpt.com/codex/tasks/task_e_68c075712a148329b05b293baa3ac086