### PR TITLE
docs: clarify PHY-only scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This project will make use of SDR hardware to receive and decode Lora.
 
+**Scope:** This repository implements the LoRa physical layer (radio layer) only.
+It includes the modulator and demodulator, Gray coding and demapping,
+interleaving, Hamming code, PHY CRC, synchronization, and related blocks.
+Higher-layer protocols such as LoRaWAN are intentionally out of scope.
+
 * Blog: https://myriadrf.org/blog/lora-modem-limesdr/
 
 ## Repository layout


### PR DESCRIPTION
## Summary
- clarify that this project implements only the LoRa PHY (modulator, demodulator, coding, interleaving, CRC, sync)

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `./build/lora_phy_tests`
- `./build/lora_gtests`
- `python tests/awgn_sweep.py --packets 100 --snr-start 0 --snr-stop 12 --snr-step 0.5 --out logs/awgn_sweep` (fails: Unsupported coding rate: 4/7)
- `./build/performance_test` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68c123d0b81083298deb8389e636b9b5