### PR TITLE
Remove LoRaWAN references

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -95,40 +95,6 @@ Returns a pointer to the metrics collected during the most recent processing
 call (`decode` or `demodulate`).  The caller must not free the returned pointer
 and it remains valid until the next call that updates the metrics.
 
-## LoRaWAN helpers
-
-An optional helper module in `include/lorawan/lorawan.hpp` provides small
-structures representing LoRaWAN headers along with utilities to build and
-parse frames.
-
-### Data structures
-
-* `lorawan::MHDR` – message header carrying the frame type and protocol major
-  version.
-* `lorawan::FHDR` – frame header containing device address, frame control,
-  frame counter and optional MAC commands (`fopts`).
-* `lorawan::Frame` – aggregates `MHDR`, `FHDR` and the FRMPayload bytes.
-
-### `ssize_t lorawan::build_frame(lora_phy::lora_workspace *ws,
-                                  const lorawan::Frame &frame,
-                                  uint16_t *symbols,
-                                  size_t symbol_cap,
-                                  uint8_t *tmp_bytes,
-                                  size_t tmp_cap);`
-Serialises `frame`, appends a CRC32-based MIC and encodes the resulting buffer
-into LoRa symbols using `lora_phy::encode`.  `tmp_bytes` must point to a caller
-provided workspace for the intermediate byte representation.  Returns the
-number of symbols written or a negative value on error.
-
-### `ssize_t lorawan::parse_frame(lora_phy::lora_workspace *ws,
-                                  const uint16_t *symbols, size_t count,
-                                  lorawan::Frame &out,
-                                  uint8_t *tmp_bytes,
-                                  size_t tmp_cap);`
-Decodes symbols with `lora_phy::decode`, verifies the MIC and populates `out`
-with the parsed fields using `tmp_bytes` as scratch space.  The return value is
-the number of payload bytes or a negative error code.
-
 ## Buffer Ownership and Error Handling
 
 All input and output buffers are owned by the caller.  The library reads from or

--- a/README_LoRaSDR_porting.md
+++ b/README_LoRaSDR_porting.md
@@ -171,8 +171,6 @@ regenerate vectors if any convention is adjusted.
   regenerate vectors with `scripts/generate_vectors.sh` to compare windowed and
   unwindowed behaviour.
 - **Additional BW**: 250/500 kHz support.
-- **LoRaWAN**: use the PHY as a base for LoRaWAN frame building/parsing later on. See
-  the “LoRaWAN helpers” section in `API_SPEC.md` for the emerging interface.
 
 ---
 


### PR DESCRIPTION
## Summary
- Strip LoRaWAN helpers section from API spec to focus docs on core PHY
- Remove LoRaWAN bullet from porting plan documentation

## Testing
- `cmake -B build -S .`
- `cmake --build build` *(fails: LoRaCodes.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c124d0f0d48329a12aac0d5e80ea8f